### PR TITLE
Remove <picture>-specific processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,5 @@ entities-unicode.inc
 entities.inc
 entities.json
 json-entities-unicode.inc
-middle-picture-spec
 unicode.xml
 w3cbugs.csv

--- a/.pre-process-annotate-attributes.pl
+++ b/.pre-process-annotate-attributes.pl
@@ -9,7 +9,6 @@ my %attributes = ();
 my @lines = ();
 my %instances = ();
 while (defined($_ = <>)) {
-    s/element-dfn-/concept-element-/og; # for <picture>
     my $line = \"$_";
     push(@lines, $line);
     if ($_ eq "  <h3 class=\"no-num\">Attributes</h3>\n") {

--- a/.pre-process-main.pl
+++ b/.pre-process-main.pl
@@ -38,10 +38,7 @@ while (@lines) {
         $lastProgress = $progress;
     }
 
-    if ($line =~ m/^ *<!-- this is where zcorpan's <picture> spec goes --> *\n$/os) {
-        unshift @lines, split("\n", `cat middle-picture-spec`);
-        next;
-    } elsif ($line =~ m|^(.*)<!--BOILERPLATE ([-.a-z0-9]+)-->(.*)\n$|os) {
+    if ($line =~ m|^(.*)<!--BOILERPLATE ([-.a-z0-9]+)-->(.*)\n$|os) {
         unshift @lines, split("\n", $1 . `cat $2` . $3);
         next;
     } elsif ($line =~ m!^( *)<pre>EXAMPLE (offline/|workers/|canvas/)((?:[-a-z0-9]+/){1,2}[-a-z0-9]+.[-a-z0-9]+)</pre> *\n$!os) {

--- a/build.sh
+++ b/build.sh
@@ -26,8 +26,7 @@ if [ unicode.xml -nt entities-unicode.inc ]; then
   perl -Tw .entity-to-dtd.pl < entities-unicode.inc > entities-dtd.url
 fi
 
-rm -rf caniuse.json w3cbugs.csv middle-picture-spec
-wget -o /dev/null -O middle-picture-spec --no-check-certificate https://raw.githubusercontent.com/ResponsiveImagesCG/picture-element/gh-pages/source
+rm -rf caniuse.json w3cbugs.csv
 wget -o /dev/null -O caniuse.json --no-check-certificate https://raw.githubusercontent.com/Fyrd/caniuse/master/data.json
 wget -o /dev/null -O w3cbugs.csv 'https://www.w3.org/Bugs/Public/buglist.cgi?columnlist=bug_file_loc,short_desc&query_format=advanced&resolution=---&ctype=csv'
 


### PR DESCRIPTION
https://github.com/whatwg/html/pull/61 includes `<picture>` directly. No
need for html-build to care anymore. Part two towards fixing
https://github.com/whatwg/html/issues/52.