### PR TITLE
Display Wattsi build server output

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -206,6 +206,7 @@ else
   fi
 
   unzip $($VERBOSE && echo "-v" || echo "-qq") $HTML_TEMP/wattsi-output.zip -d $HTML_TEMP/wattsi-output
+  cat $HTML_TEMP/wattsi-output/output.txt
 fi
 
 cat $HTML_TEMP/wattsi-output/index-html | perl .post-process-index-generator.pl | perl .post-process-partial-backlink-generator.pl > $HTML_OUTPUT/index;


### PR DESCRIPTION
Fixes #21.

Not silencing this yet until we have --quiet (and the build server will then presumably get `?quiet`)