### PR TITLE
Fix #42: Use a space before combining character entities

### DIFF
--- a/.entity-processor-json.py
+++ b/.entity-processor-json.py
@@ -36,6 +36,9 @@ for entity in document.getElementsByTagName('entity'):
     assert len(name) > 0
     assert entity.parentNode.hasAttribute('id')
     value = entity.parentNode.getAttribute('id')
+    combining = entity.parentNode.getElementsByTagName('description')[0].childNodes[0].data[:9] == 'COMBINING'
+    if (combining):
+      value = 'U00020-' + value[1:]
     assert name not in entities or entities[name] == value, '(name: ' + name + ' old value: ' + entities[name] + ' new value: ' + value + ')'
     if (name not in entities):
       entities[name] = value

--- a/.entity-processor.py
+++ b/.entity-processor.py
@@ -22,6 +22,9 @@ for entity in document.getElementsByTagName('entity'):
     assert len(name) > 0
     assert entity.parentNode.hasAttribute('id')
     value = entity.parentNode.getAttribute('id')
+    combining = entity.parentNode.getElementsByTagName('description')[0].childNodes[0].data[:9] == 'COMBINING'
+    if (combining):
+      value = 'U00020-' + value[1:]
     assert name not in entities or entities[name] == value, '(name: ' + name + ' old value: ' + entities[name] + ' new value: ' + value + ')'
     if (name not in entities):
       entities[name] = value


### PR DESCRIPTION
This implements the same logic as https://github.com/w3c/xml-entities/blob/gh-pages/entities.xsl#L217-L219.

See #42.