### PR TITLE
Use demos from the source repository

### DIFF
--- a/.pre-process-main.pl
+++ b/.pre-process-main.pl
@@ -47,27 +47,17 @@ while (@lines) {
         my $indent = $1;
         my $folder = $2;
         my $example = $3;
-        # TODO: maybe move these to the HTML source repo, and upload them to whatwg.org from there?
-        # Or maybe better, redirect from these URLs to new html.spec.whatwg.org URLs
-        my $url = "https://whatwg.org/demos/$folder$example";
+
         my $data;
         my $fh;
-        mkpath(dirname("$ENV{'HTML_CACHE'}/demos/$folder$example"));
-        if (-e "$ENV{'HTML_CACHE'}/demos/$folder$example" && "false" eq "$ENV{'DO_UPDATE'}") {
-          report "\r\nReading $ENV{'HTML_CACHE'}/demos/$folder$example";
-          open($fh, "<:encoding(UTF-8)", "$ENV{'HTML_CACHE'}/demos/$folder$example");
-          while (<$fh>) {
-            $data .= $_;
-          }
-          close $fh;
-        } else {
-          report "\r\n\nReading $url\n";
-          $data = `curl \$(\$VERBOSE && echo "-v" || echo "-s") $url`;
-          report "\rWriting $ENV{'HTML_CACHE'}/demos/$folder$example";
-          open($fh, '>', "$ENV{'HTML_CACHE'}/demos/$folder$example");
-          print $fh $data;
-          close $fh;
+
+        open($fh, "<:encoding(UTF-8)", "$ENV{'HTML_SOURCE'}/demos/$folder$example")
+          or die "\rCannot open $ENV{'HTML_SOURCE'}/demos/$folder$example";
+        while (<$fh>) {
+          $data .= $_;
         }
+        close $fh;
+
         $data =~ s/&/&amp;/gos;
         $data =~ s/</&lt;/gos;
         unshift @lines, split("\n", "$indent<pre>$data</pre>");

--- a/build.sh
+++ b/build.sh
@@ -325,6 +325,7 @@ cp -p  $HTML_SOURCE/.htaccess $HTML_OUTPUT
 cp -p  $HTML_SOURCE/404.html $HTML_OUTPUT
 cp -pR $HTML_SOURCE/fonts $HTML_OUTPUT
 cp -pR $HTML_SOURCE/images $HTML_OUTPUT
+cp -pR $HTML_SOURCE/demos $HTML_OUTPUT
 cp -pR $HTML_SOURCE/link-fixup.js $HTML_OUTPUT
 
 $QUIET || echo


### PR DESCRIPTION
Part of whatwg/html#30. Depends on whatwg/html#445 landing first.

I removed the "Reading DEMO_PATH" line since it goes by so fast as to not seem useful, but maybe we should keep it. Thoughts?