### PR TITLE
Make it possible to invoke build.sh from anywhere

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,8 +2,9 @@
 set -e
 HTML_GIT_CLONE_OPTIONS=${HTML_GIT_CLONE_OPTIONS:-"--depth 1"}
 
-# Absolute path to the directory containing this script
-DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+# cd to the directory containing this script
+cd "$( dirname "${BASH_SOURCE[0]}" )"
+DIR=$(pwd)
 
 DO_UPDATE=true
 VERBOSE=false


### PR DESCRIPTION
Simply cd to its directory and simplify the uses of $DIR.

Drive-by: Drop -k which makes curl accept insecure connections