### PR TITLE
Print wattsi's output in case of build failure with --quiet

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -270,10 +270,10 @@ function runWattsi {
 }
 
 runWattsi $HTML_TEMP/source-whatwg-complete $HTML_TEMP/wattsi-output
-$QUIET || cat $HTML_TEMP/wattsi-output.txt | grep -v '^$' # trim blank lines
-
-if [ "$WATTSI_RESULT" != "0" ]; then
-  $QUIET && exit $WATTSI_RESULT
+if [ "$WATTSI_RESULT" == "0" ]; then
+    $QUIET || cat $HTML_TEMP/wattsi-output.txt | grep -v '^$' # trim blank lines
+else
+  cat $HTML_TEMP/wattsi-output.txt | grep -v '^$' # trim blank lines
   if [ "$WATTSI_RESULT" == "65" ]; then
     echo
     echo "There were errors. Running again to show the original line numbers."


### PR DESCRIPTION
Because wattsi's output also respects --quiet, it will look something
like this:

```
Parse Error: (35825,9) unexpected end tag

There were errors. Running again to show the original line numbers.

Parse Error: (35645,9) unexpected end tag

There were errors. Stopping.
```

Follow-up to https://github.com/whatwg/html-build/pull/58