### PR TITLE
Download a smaller list of bugs from W3C's Bugzilla

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -230,10 +230,10 @@ fi
 
 if [ "$DO_UPDATE" == true ] || [ ! -f $HTML_CACHE/w3cbugs.csv ]; then
   rm -f $HTML_CACHE/w3cbugs.csv
-  $QUIET || echo "Downloading list of W3C bugzilla bugs (can be a wee bit slow)..."
+  $QUIET || echo "Downloading list of W3C bugzilla bugs..."
   curl $($VERBOSE || echo "-s") \
     -o $HTML_CACHE/w3cbugs.csv \
-    'https://www.w3.org/Bugs/Public/buglist.cgi?columnlist=bug_file_loc,short_desc&query_format=advanced&resolution=---&ctype=csv&status_whiteboard=whatwg-resolved&status_whiteboard_type=notregexp'
+    'https://www.w3.org/Bugs/Public/buglist.cgi?columnlist=bug_file_loc,short_desc&query_format=advanced&resolution=---&ctype=csv&status_whiteboard=whatwg-resolved&status_whiteboard_type=notregexp&bug_file_loc=http&bug_file_loc_type=substring&product=WHATWG&product=HTML%20WG&product=CSS&product=WebAppsWG'
 fi
 
 $QUIET || echo


### PR DESCRIPTION
Limit the search to bugs that have a URL and are in interesting
components.

This shrinks the downloaded w3cbugs.cvs from 3211 bugs (242 kB) to 265
bugs (40 kB), with corresponding savings in transfer time both when
downloaded and then uploading to the wattsi build server.

This removes the following HTML Checker and SVG bugs from the output:
https://www.w3.org/Bugs/Public/show_bug.cgi?id=13648
https://www.w3.org/Bugs/Public/show_bug.cgi?id=13649
https://www.w3.org/Bugs/Public/show_bug.cgi?id=16125
https://www.w3.org/Bugs/Public/show_bug.cgi?id=23157
https://www.w3.org/Bugs/Public/show_bug.cgi?id=23165
https://www.w3.org/Bugs/Public/show_bug.cgi?id=23753

Based on findings from https://github.com/whatwg/html/issues/619