### PR TITLE
Move lint to a separate script that runs before build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -199,6 +199,13 @@ else
 fi
 export HTML_SOURCE
 
+$QUIET || echo "Linting the source file..."
+./lint.sh $HTML_SOURCE/source || {
+  echo
+  echo "There were lint errors. Stopping."
+  exit 1
+}
+
 rm -rf $HTML_TEMP && mkdir -p $HTML_TEMP
 rm -rf $HTML_OUTPUT && mkdir -p $HTML_OUTPUT
 
@@ -316,16 +323,6 @@ cp -pR $HTML_SOURCE/fonts $HTML_OUTPUT
 cp -pR $HTML_SOURCE/images $HTML_OUTPUT
 cp -pR $HTML_SOURCE/demos $HTML_OUTPUT
 cp -pR $HTML_SOURCE/link-fixup.js $HTML_OUTPUT
-
-$QUIET || echo "Linting the output..."
-# show potential problems
-# note - would be nice if the ones with \s+ patterns actually cross lines, but, they don't...
-grep -ni 'xxx' $HTML_SOURCE/source| perl -lpe 'print "\nPossible incomplete sections:" if $. == 1'
-grep -niE '( (code|span|var)(>| data-x=)|[^<;]/(code|span|var)>)' $HTML_SOURCE/source| perl -lpe 'print "\nPossible copypasta:" if $. == 1'
-grep -ni 'chosing\|approprate\|occured\|elemenst\|\bteh\b\|\blabelled\b\|\blabelling\b\|\bhte\b\|taht\|linx\b\|speciication\|attribue\|kestern\|horiontal\|\battribute\s\+attribute\b\|\bthe\s\+the\b\|\bthe\s\+there\b\|\bfor\s\+for\b\|\bor\s\+or\b\|\bany\s\+any\b\|\bbe |be\b\|\bwith\s\+with\b\|\bis\s\+is\b' $HTML_SOURCE/source| perl -lpe 'print "\nPossible typos:" if $. == 1'
-perl -ne 'print "$.: $_" if (/\ban (<[^>]*>)*(?!(L\b|http|https|href|hgroup|rb|rp|rt|rtc|li|xml|svg|svgmatrix|hour|hr|xhtml|xslt|xbl|nntp|mpeg|m[ions]|mtext|merror|h[1-6]|xmlns|xpath|s|x|sgml|huang|srgb|rsa|only|option|optgroup)\b|html)[b-df-hj-np-tv-z]/i or /\b(?<![<\/;])a (?!<!--grammar-check-override-->)(<[^>]*>)*(?!&gt|one)(?:(L\b|http|https|href|hgroup|rt|rp|li|xml|svg|svgmatrix|hour|hr|xhtml|xslt|xbl|nntp|mpeg|m[ions]|mtext|merror|h[1-6]|xmlns|xpath|s|x|sgml|huang|srgb|rsa|only|option|optgroup)\b|html|[aeio])/i)' $HTML_SOURCE/source| perl -lpe 'print "\nPossible article problems:" if $. == 1'
-grep -ni 'and/or' $HTML_SOURCE/source| perl -lpe 'print "\nOccurrences of making Ms2ger unhappy and/or annoyed:" if $. == 1'
-grep -ni 'throw\s\+an\?\s\+<span' $HTML_SOURCE/source| perl -lpe 'print "\nException marked using <span> rather than <code>:" if $. == 1'
 
 $QUIET || echo
 $QUIET || echo "Success!"

--- a/lint.sh
+++ b/lint.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 path/to/html/source"
+  exit 1
+fi
+
+# show potential problems
+# note - would be nice if the ones with \s+ patterns actually cross lines, but, they don't...
+MATCHES=$(grep -ni 'xxx' $1 | perl -lpe 'print "\nPossible incomplete sections:" if $. == 1'
+  grep -niE '( (code|span|var)(>| data-x=)|[^<;]/(code|span|var)>)' $1 | perl -lpe 'print "\nPossible copypasta:" if $. == 1'
+  grep -ni 'chosing\|approprate\|occured\|elemenst\|\bteh\b\|\blabelled\b\|\blabelling\b\|\bhte\b\|taht\|linx\b\|speciication\|attribue\|kestern\|horiontal\|\battribute\s\+attribute\b\|\bthe\s\+the\b\|\bthe\s\+there\b\|\bfor\s\+for\b\|\bor\s\+or\b\|\bany\s\+any\b\|\bbe |be\b\|\bwith\s\+with\b\|\bis\s\+is\b' $1 | perl -lpe 'print "\nPossible typos:" if $. == 1'
+  perl -ne 'print "$.: $_" if (/\ban (<[^>]*>)*(?!(L\b|http|https|href|hgroup|rb|rp|rt|rtc|li|xml|svg|svgmatrix|hour|hr|xhtml|xslt|xbl|nntp|mpeg|m[ions]|mtext|merror|h[1-6]|xmlns|xpath|s|x|sgml|huang|srgb|rsa|only|option|optgroup)\b|html)[b-df-hj-np-tv-z]/i or /\b(?<![<\/;])a (?!<!--grammar-check-override-->)(<[^>]*>)*(?!&gt|one)(?:(L\b|http|https|href|hgroup|rt|rp|li|xml|svg|svgmatrix|hour|hr|xhtml|xslt|xbl|nntp|mpeg|m[ions]|mtext|merror|h[1-6]|xmlns|xpath|s|x|sgml|huang|srgb|rsa|only|option|optgroup)\b|html|[aeio])/i)' $1 | perl -lpe 'print "\nPossible article problems:" if $. == 1'
+  grep -ni 'and/or' $1 | perl -lpe 'print "\nOccurrences of making Ms2ger unhappy and/or annoyed:" if $. == 1'
+  grep -ni 'throw\s\+an\?\s\+<span' $1 | perl -lpe 'print "\nException marked using <span> rather than <code>:" if $. == 1')
+
+if [ -n "$MATCHES" ]; then
+  echo "$MATCHES"
+  exit 1
+fi


### PR DESCRIPTION
Closes #70.

I would like to make the build fail if lint fails, but I can't figure out how to make those multiline grep/perl statements cause that. Ideally all of them would execute, and if any of them output anything, we'd return 1. Anyone know enough bash for that?