### PR TITLE
Allow using Docker to build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git/
+.cache/
+.temp/
+output/
+html/.git/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM debian:sid
+
+## dependency installation: apache, wattsi, and other build tools
+## enable some apache mods (the ln -s lines)
+## cleanup freepascal since it is no longer needed after wattsi build
+RUN apt-get update && \
+    apt-get install -y ca-certificates curl git unzip fp-compiler-3.0.0 apache2 && \
+    cd /etc/apache2/mods-enabled && \
+    ln -s ../mods-available/headers.load && \
+    ln -s ../mods-available/expires.load && \
+    git clone https://github.com/whatwg/wattsi.git /whatwg/wattsi && \
+    cd /whatwg/wattsi && \
+    /whatwg/wattsi/build.sh && \
+    cp /whatwg/wattsi/bin/wattsi /bin/ && \
+    apt-get purge -y fp-compiler-3.0.0 && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
+
+ADD . /whatwg/build
+
+ARG html_source_dir
+ADD $html_source_dir /whatwg/html
+ENV HTML_SOURCE /whatwg/html
+
+WORKDIR /whatwg/build
+
+## build and copy assets to final apache dir
+
+ARG verbose_or_quiet_flag
+ARG no_update_flag
+
+# no_update_flag doesn't really work; .cache directory is re-created empty each time
+RUN SKIP_BUILD_UPDATE_CHECK=true ./build.sh $verbose_or_quiet_flag $no_update_flag && \
+    rm -rf /var/www/html && \
+    mv output /var/www/html && \
+    chmod -R o+rX /var/www/html && \
+    cp site.conf /etc/apache2/sites-available/000-default.conf
+
+CMD ["apache2ctl", "-DFOREGROUND"]

--- a/README.md
+++ b/README.md
@@ -2,34 +2,39 @@
 
 This repository contains the tools and instructions necessary for building the [HTML Standard](https://html.spec.whatwg.org/multipage/) from its [source](https://github.com/whatwg/html).
 
-## Prerequisites
+## Getting set up
 
-Before building, make sure you have the following commands installed on your system.
+Make sure you have `git` installed on your system, and you are using a Bash shell. (On Windows, `cmd.exe` will not work, but the Git Bash shell that comes with [Git for Windows](https://git-for-windows.github.io/) works nicely.)
 
-- `curl`, `git`, `grep`, `perl`, `unzip`
+Then, clone this ([html-build](https://github.com/whatwg/html-build)) repo:
 
-Optionally, for faster builds, you can install [Wattsi](https://github.com/whatwg/wattsi) on your system. If you don't bother with that, the build will use [Wattsi Server](https://github.com/domenic/wattsi-server).
+```
+git clone https://github.com/whatwg/html-build.git && cd html-build
+```
 
-## Build
+You then have a decision to make as to how you want to do your builds: locally, on your computer, or using a [Docker](https://www.docker.com/) container. We suggest going the Docker route if and only if you are already comfortable with Docker.
 
-Building your own copy of the HTML Standard from its source requires just these simple steps:
+## Building locally
 
-1. If you want to submit a pull request to the [whatwg/html](https://github.com/whatwg/html) repo, fork it and clone your fork. (If not, you can skip this step.)
- ```
- git clone https://github.com/<username>/html.git
- ```
+### Prerequisites
 
-1. Clone this ([html-build](https://github.com/whatwg/html-build)) repo:
- ```
- git clone https://github.com/whatwg/html-build.git && cd html-build
- ```
+To build locally, you'll need the following commands installed on your system:
 
-1. Run the `build.sh` script from inside your `html-build` working directory, like this:
- ```
- ./build.sh
- ```
+- `curl`, `grep`, `perl`, `unzip`
 
-## Output
+Optionally, for faster builds, you can install [Wattsi](https://github.com/whatwg/wattsi). If you don't bother with that, the build will use [Wattsi Server](https://github.com/domenic/wattsi-server), which requires an internet connection.
+
+### Running the build
+
+Run the `build.sh` script from inside your `html-build` working directory, like this:
+
+```
+./build.sh
+```
+
+The first time this runs, it will ask for your input on where to clone the HTML source from, or where on your system to find it if you've already done that. If you're working to submit a pull request to [whatwg/html](https://github.com/whatwg/html), be sure to give it the URL of your fork.
+
+### Output
 
 After you complete the build steps above, the build will run and generate the single-page version of the spec, the multipage version, and more. If all goes well, you should very soon have all the following in your `output/` directory:
 
@@ -42,16 +47,36 @@ After you complete the build steps above, the build will run and generate the si
 - `link-fixup.js`
 - `multipage/*`
 
-And then you're also ready to edit the `html/source` file—and after you make your changes, you can run the `build.sh` script again to see the new output.
+Now you're ready to edit the `html/source` file—and after you make your changes, you can run the `build.sh` script again to see the new output.
 
-## Options
+## Building using a Docker container
 
-Your clone doesn't need the HTML standard's complete revision history just for you to build the spec and contribute patches. So, by default we don't start you out with a clone of the history. That makes your first build finish much faster. And if later you decide you do want to clone the complete history, you can still get it, by doing this:
+The Dockerized version of the build allows you to run the build entirely inside a "container" (lightweight virtual machine). This includes tricky dependencies like a local copy of Wattsi, as well as the Apache HTTP server with a setup analogous to that of https://html.spec.whatwg.org.
+
+To perform a Dockerized build, use the `--docker` flag:
+
+```
+./build.sh --docker
+```
+
+The first time you do this, Docker will download a bunch of stuff to set up the container properly, but subsequent runs will simply build the standard and be very fast.
+
+After building the standard, this will launch a HTTP server that allows you to view the result at `http://localhost:8080`. (OS X and Windows users will need to use the IP address of their docker-machine VM instead of `localhost`. You can get this with the `docker-machine env` command.)
+
+Note that due to the way Docker works, the HTML source repository must be contained in a subdirectory of the `html-build` working directory. This will happen automatically if you let `build.sh` clone for you, but if you have a preexisting clone you'll need to move it.
+
+## A note on Git history
+
+Your clone doesn't need the HTML standard's complete revision history just for you to build the spec and contribute patches. So, if you use `build.sh` to create the clone, we don't start you out with a clone of the history. That makes your first build finish much faster. And if later you decide you do want to clone the complete history, you can still get it, by doing this:
+
 ```
 cd ./html && git fetch --unshallow
 ```
+
 That said, if you really do want to *start out* with the complete history of the repo, then run the build script for the first time like this:
+
 ```
 HTML_GIT_CLONE_OPTIONS="" ./build.sh
 ```
+
 That will clone the complete history for you. But be warned: It'll make your first build take *dramatically* longer to finish!

--- a/site.conf
+++ b/site.conf
@@ -1,0 +1,13 @@
+<VirtualHost *:80>
+    DocumentRoot /var/www/html
+
+    <Directory "/var/www/html">
+        Options Indexes FollowSymLinks
+        AllowOverride All
+        Require all granted
+    </Directory>
+
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+</VirtualHost>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet


### PR DESCRIPTION
Closes #55. Supercedes whatwg/html#612.

@defunctzombie, this is what I came up with after the discussions on https://github.com/whatwg/html/pull/612. I think we may eventually consider harder merging the html-build and html repos, but until we do, this seems to fit better with the current infrastructure. I think we do all appreciate though your perspective that we are making life harder on contributors by not letting them just clone one repo and go.

Notably, this setup allows us to reuse `./build.sh` as the main entry point, which does things like check for updates and guide the users through cloning `whatwg/html`. It thus helps hide the potentially-scary docker commands behind a nicer facade.

I'd appreciate any review, both from @defunctzombie for the mutilations I made to his beautiful setup, and from other editors who are willing to give this a shot, or review the new README.md.

Also, if anyone has ideas on how to best solve the

```
# TODO: pass in $DO_UPDATE, $QUIET, and $VERBOSE?
```

that'd be swell. (Basically, if those are set in the outer invocation of build.sh, then the Dockerfile should pass the corresponding --no-update, --quiet, or --verbose flags onward. I can imagine several ways to do this, all fairly inelegant.)