### PR TITLE
Allow attributes in `partial interface <dfn ...>` in index generator

### DIFF
--- a/.pre-process-index-generator.pl
+++ b/.pre-process-index-generator.pl
@@ -8,7 +8,7 @@ my %definitions;
 my $inpre = 0;
 while (<>) {
     $inpre = 1 if /<pre class="idl">/os;
-    if ($inpre && /(partial )?interface <(span|dfn|a href=#[^ >]*)( id="?([^ ">]*)"?)?>([^<:]*)?<\/(span|dfn|a)>/os) {
+    if ($inpre && /(partial )?interface <(span|dfn|a href=#[^ >]*)( id="?([^ ">]*)"?)?[^>]*>([^<:]*)?<\/(span|dfn|a)>/os) {
         my $partial = $1;
         my $id;
         my $name;


### PR DESCRIPTION
Ref. https://github.com/whatwg/html/pull/1733

---

I tested building the spec on html pr/1733 branch to verify that Document is in the All Interfaces index.