### PR TITLE
Enforce LF for all files.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+*.conf  text eol=lf
+*.inc   text eol=lf
+*.json  text eol=lf
+*.md    text eol=lf
+*.pl    text eol=lf
+*.py    text eol=lf
+*.sh    text eol=lf
+*.yml   text eol=lf


### PR DESCRIPTION
We still need the following:

- [ ] Merge https://github.com/whatwg/html/pull/2233
- [x] ~~Find out why the linter fails with `Trailing whitespace:`, from [here](https://github.com/whatwg/html-build/blob/master/lint.sh#L17)~~ This is due to the old grep version MSYS has.