### PR TITLE
Add a lint check for accidental RFC2119 keywords in notes/examples

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -14,7 +14,8 @@ MATCHES=$(grep -ni 'xxx' $1 | perl -lpe 'print "\nPossible incomplete sections:"
   grep -niE '((anonym|author|categor|custom|emphas|initial|local|minim|neutral|normal|optim|raster|real|recogn|roman|serial|standard|summar|synchron|synthes|token|optim)is(e|ing|ation|ability)|(col|behavi|hono|fav)our)' $1 | grep -vE "\ben-GB\b" | perl -lpe 'print "\nen-GB spelling (use lang=\"en-GB\", or <!-- en-GB -->, on the same line to override):" if $. == 1'
   perl -ne 'print "$.: $_" if (/\ban (<[^>]*>)*(?!(L\b|http|https|href|hgroup|rb|rp|rt|rtc|li|xml|svg|svgmatrix|hour|hr|xhtml|xslt|xbl|nntp|mpeg|m[ions]|mtext|merror|h[1-6]|xmlns|xpath|s|x|sgml|huang|srgb|rsa|only|option|optgroup)\b|html)[b-df-hj-np-tv-z]/i or /\b(?<![<\/;])a (?!<!--grammar-check-override-->)(<[^>]*>)*(?!&gt|one)(?:(L\b|http|https|href|hgroup|rt|rp|li|xml|svg|svgmatrix|hour|hr|xhtml|xslt|xbl|nntp|mpeg|m[ions]|mtext|merror|h[1-6]|xmlns|xpath|s|x|sgml|huang|srgb|rsa|only|option|optgroup)\b|html|[aeio])/i)' $1 | perl -lpe 'print "\nPossible article problems:" if $. == 1'
   grep -ni 'and/or' $1 | perl -lpe 'print "\nOccurrences of making Ms2ger unhappy and/or annoyed:" if $. == 1'
-  grep -niE '\s+$' $1 | perl -lpe 'print "\nTrailing whitespace:" if $. == 1')
+  grep -niE '\s+$' $1 | perl -lpe 'print "\nTrailing whitespace:" if $. == 1'
+  perl -ne 'print "$.: $_" if (/class="?(note|example).+(\n.+)*\s+(should|must|may|optional|recommended)(\s|$)/i)' $1 | perl -lpe 'print "\nRFC2119 keyword in example or note (use: might, can, has to, or override with <!--non-normative-->must):" if $. == 1')
 
 if [ -n "$MATCHES" ]; then
   echo "$MATCHES"


### PR DESCRIPTION
See https://github.com/whatwg/html/pull/2347