### PR TITLE
Enable cross-multipage dfn.js

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -426,6 +426,7 @@ else
 fi
 
 perl .post-process-partial-backlink-generator.pl "$HTML_TEMP/wattsi-output/index-html" > "$HTML_OUTPUT/index.html";
+cp -p  "$HTML_TEMP/wattsi-output/xrefs.json" "$HTML_OUTPUT"
 cp -p  entities/out/entities.json "$HTML_OUTPUT"
 
 # multipage setup


### PR DESCRIPTION
This change copies the xrefs.json file generated by wattsi to the
expected place in the root of the output dir.

Depends on:

* https://github.com/whatwg/html/pull/2638
* https://github.com/whatwg/resources.whatwg.org/pull/56
* https://github.com/whatwg/wattsi/pull/46