### PR TITLE
Generate print.pdf during the CI build

### DIFF
--- a/ci-deploy/Dockerfile
+++ b/ci-deploy/Dockerfile
@@ -3,8 +3,7 @@
 FROM debian:sid
 
 RUN apt-get update && \
-    apt-get install -y ca-certificates curl rsync git unzip fp-compiler default-jre fonts-dejavu \
-                       fonts-droid netpbm sam2p
+    apt-get install -y ca-certificates curl rsync git unzip fp-compiler default-jre
 
 ADD wattsi /whatwg/wattsi
 
@@ -12,11 +11,17 @@ RUN cd /whatwg/wattsi && \
     /whatwg/wattsi/build.sh
 ENV PATH="/whatwg/wattsi/bin:${PATH}"
 
-ADD prince.tar.gz /whatwg/prince.tar.gz
+ADD https://www.princexml.com/download/prince-11.3-linux-generic-x86_64.tar.gz /whatwg/prince.tar.gz
 
-RUN tar xzf /whatwg/prince.tar.gz && \
-    /whatwg/prince/install.sh /whatwg/prince
-ENV PATH="/whatwg/prince/bin/prince:${PATH}"
+# Dependecies of prince_11.3-1_debian8.0_amd64.deb (not used) are libc6 libcurl3 libfontconfig1
+# libfreetype6 libgif4 libgomp1 libjpeg62-turbo libpng12-0 libssl1.0.0 libtiff5 libxml2 zlib1g.
+# Install the subset of that that's needed to make prince work and fonts.
+RUN apt-get update && apt-get install -y libfontconfig1 libgomp1 libxml2 \
+    fonts-dejavu fonts-droid-fallback && \
+    cd /whatwg && \
+    tar xzf prince.tar.gz && \
+    echo | /whatwg/prince-11.3-linux-generic-x86_64/install.sh && \
+    rm -rf /whatwg/prince.tar.gz /whatwg/prince-11.3-linux-generic-x86_64
 
 ADD html-build /whatwg/html-build
 

--- a/ci-deploy/Dockerfile
+++ b/ci-deploy/Dockerfile
@@ -3,13 +3,20 @@
 FROM debian:sid
 
 RUN apt-get update && \
-    apt-get install -y ca-certificates curl rsync git unzip fp-compiler default-jre
+    apt-get install -y ca-certificates curl rsync git unzip fp-compiler default-jre fonts-dejavu \
+                       fonts-droid netpbm sam2p
 
 ADD wattsi /whatwg/wattsi
 
 RUN cd /whatwg/wattsi && \
     /whatwg/wattsi/build.sh
 ENV PATH="/whatwg/wattsi/bin:${PATH}"
+
+ADD prince.tar.gz /whatwg/prince.tar.gz
+
+RUN tar xzf /whatwg/prince.tar.gz && \
+    /whatwg/prince/install.sh /whatwg/prince
+ENV PATH="/whatwg/prince/bin/prince:${PATH}"
 
 ADD html-build /whatwg/html-build
 

--- a/ci-deploy/Dockerfile
+++ b/ci-deploy/Dockerfile
@@ -17,10 +17,11 @@ ADD https://www.princexml.com/download/prince-11.3-linux-generic-x86_64.tar.gz /
 # libfreetype6 libgif4 libgomp1 libjpeg62-turbo libpng12-0 libssl1.0.0 libtiff5 libxml2 zlib1g.
 # Install the subset of that that's needed to make prince work and fonts.
 RUN apt-get update && apt-get install -y libfontconfig1 libgomp1 libxml2 \
-    fonts-dejavu fonts-droid-fallback && \
+    fonts-dejavu fonts-droid-fallback fonts-liberation fonts-symbola fonts-unfonts-core && \
     cd /whatwg && \
     tar xzf prince.tar.gz && \
     echo /whatwg/prince | /whatwg/prince-11.3-linux-generic-x86_64/install.sh && \
+    echo '@font-face { font-family: serif; src: local("Symbola") }' >> /whatwg/prince/lib/prince/style/fonts.css && \
     rm -rf /whatwg/prince.tar.gz /whatwg/prince-11.3-linux-generic-x86_64
 ENV PATH="/whatwg/prince/bin:${PATH}"
 

--- a/ci-deploy/Dockerfile
+++ b/ci-deploy/Dockerfile
@@ -20,8 +20,17 @@ RUN apt-get update && apt-get install -y libfontconfig1 libgomp1 libxml2 \
     fonts-dejavu fonts-droid-fallback && \
     cd /whatwg && \
     tar xzf prince.tar.gz && \
-    echo | /whatwg/prince-11.3-linux-generic-x86_64/install.sh && \
+    echo /whatwg/prince | /whatwg/prince-11.3-linux-generic-x86_64/install.sh && \
     rm -rf /whatwg/prince.tar.gz /whatwg/prince-11.3-linux-generic-x86_64
+ENV PATH="/whatwg/prince/bin:${PATH}"
+
+ADD pdfsizeopt/pdfsizeopt.single /whatwg/pdfsizeopt/bin/pdfsizeopt
+ADD https://github.com/pts/pdfsizeopt/releases/download/2017-01-24/pdfsizeopt_libexec_linux-v3.tar.gz /whatwg/pdfsizeopt_libexec.tar.gz
+RUN cd /whatwg && \
+    tar xzf pdfsizeopt_libexec.tar.gz && \
+    mv pdfsizeopt_libexec/* pdfsizeopt/bin/ && \
+    rm -rf pdfsizeopt_libexec.tar.gz pdfsizeopt_libexec
+ENV PATH="/whatwg/pdfsizeopt/bin:${PATH}"
 
 ADD html-build /whatwg/html-build
 

--- a/ci-deploy/inside-container.sh
+++ b/ci-deploy/inside-container.sh
@@ -41,11 +41,6 @@ if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
   exit 0
 fi
 
-# Build the PDF using Prince
-prince --help
-prince --verbose --output "$HTML_OUTPUT/print.pdf" "$PDF_SOURCE_URL"
-pdfsizeopt "$HTML_OUTPUT/print.pdf" "$HTML_OUTPUT/print-opt.pdf"
-
 # Add the (decoded) deploy key to the SSH agent, so scp works
 chmod 600 html/deploy-key
 eval "$(ssh-agent -s)"
@@ -80,6 +75,12 @@ echo "Deploying commit snapshot to new server..."
 rsync --rsh="ssh -o UserKnownHostsFile=known_hosts" \
       --archive --compress --verbose \
       "$HTML_OUTPUT/index.html" "deploy@$NEW_SERVER:/var/www/$WEB_ROOT/commit-snapshots/$HTML_SHA"
+
+echo ""
+echo "Building PDF..."
+PDF_TMP="$(mktemp --suffix=.pdf)"
+prince --verbose --output "$PDF_TMP" "$PDF_SOURCE_URL"
+pdfsizeopt "$PDF_TMP" "$HTML_OUTPUT/print.pdf"
 
 echo ""
 echo "Deploying PDF..."

--- a/ci-deploy/inside-container.sh
+++ b/ci-deploy/inside-container.sh
@@ -41,6 +41,11 @@ if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
   exit 0
 fi
 
+# Build the PDF using Prince
+prince --help
+prince --verbose --output "$HTML_OUTPUT/print.pdf" "$PDF_SOURCE_URL"
+pdfsizeopt "$HTML_OUTPUT/print.pdf" "$HTML_OUTPUT/print-opt.pdf"
+
 # Add the (decoded) deploy key to the SSH agent, so scp works
 chmod 600 html/deploy-key
 eval "$(ssh-agent -s)"
@@ -75,10 +80,6 @@ echo "Deploying commit snapshot to new server..."
 rsync --rsh="ssh -o UserKnownHostsFile=known_hosts" \
       --archive --compress --verbose \
       "$HTML_OUTPUT/index.html" "deploy@$NEW_SERVER:/var/www/$WEB_ROOT/commit-snapshots/$HTML_SHA"
-
-# Build the PDF using Prince
-prince --verbose --output "$HTML_OUTPUT/print.pdf" "$PDF_SOURCE_URL"
-# TODO: optimize
 
 echo ""
 echo "Deploying PDF..."

--- a/ci-deploy/outside-container.sh
+++ b/ci-deploy/outside-container.sh
@@ -18,9 +18,6 @@ TRAVIS_PULL_REQUEST=${TRAVIS_PULL_REQUEST:-false}
 
 git clone https://github.com/whatwg/wattsi.git wattsi
 
-curl --output prince.tar.gz --fail \
-     https://www.princexml.com/download/prince-11.3-linux-generic-x86_64.tar.gz
-
 # Copy the Docker-related stuff into the working (grandparent) directory.
 cp "$HERE"/{.dockerignore,Dockerfile} .
 

--- a/ci-deploy/outside-container.sh
+++ b/ci-deploy/outside-container.sh
@@ -16,9 +16,9 @@ TRAVIS_PULL_REQUEST=${TRAVIS_PULL_REQUEST:-false}
 # - DOCKER_PASSWORD is set from the outside
 # - ENCRYPTION_LABEL is set from the outside
 
-git clone https://github.com/whatwg/wattsi.git wattsi
+git clone --depth 1 https://github.com/whatwg/wattsi.git wattsi
 
-git clone https://github.com/pts/pdfsizeopt.git pdfsizeopt
+git clone --depth 1 https://github.com/pts/pdfsizeopt.git pdfsizeopt
 
 # Copy the Docker-related stuff into the working (grandparent) directory.
 cp "$HERE"/{.dockerignore,Dockerfile} .

--- a/ci-deploy/outside-container.sh
+++ b/ci-deploy/outside-container.sh
@@ -18,6 +18,8 @@ TRAVIS_PULL_REQUEST=${TRAVIS_PULL_REQUEST:-false}
 
 git clone https://github.com/whatwg/wattsi.git wattsi
 
+git clone https://github.com/pts/pdfsizeopt.git pdfsizeopt
+
 # Copy the Docker-related stuff into the working (grandparent) directory.
 cp "$HERE"/{.dockerignore,Dockerfile} .
 

--- a/ci-deploy/outside-container.sh
+++ b/ci-deploy/outside-container.sh
@@ -18,6 +18,9 @@ TRAVIS_PULL_REQUEST=${TRAVIS_PULL_REQUEST:-false}
 
 git clone https://github.com/whatwg/wattsi.git wattsi
 
+curl --output prince.tar.gz --fail \
+     https://www.princexml.com/download/prince-11.3-linux-generic-x86_64.tar.gz
+
 # Copy the Docker-related stuff into the working (grandparent) directory.
 cp "$HERE"/{.dockerignore,Dockerfile} .
 


### PR DESCRIPTION
/cc @izh1979 @foolip.

Not ready yet; this is based on https://github.com/foolip/makepdf/blob/travis/.travis.yml, just converted to Docker form (so that e.g. the cached image contains prince and the dependencies all installed and ready to go).

My reading on potential to-dos left, in order of decreasing importance:

- [x] Add missing fonts, and apply the [fonts diff](https://github.com/izh1979/makepdf/blob/master/fonts/prince11-fonts.diff) to prince
- [x] Add pdfsizeopt step; I omitted this because I wasn't sure how we wanted to install it. I guess we can do similar to what we do with prince, using the .tar.gz specified in https://github.com/pts/pdfsizeopt.
- [x] Use pngout when doing the pdfsizeopt; this probably requires installing pngout. Saves ~ 5 KiB but should be easy?
- [ ] Try to make multivalent work? Saves ~114 KiB, but might be hard.

Anything else we're missing?