### PR TITLE
Stop buffering wattsi output when run locally

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -415,6 +415,9 @@ if [[ "$WATTSI_RESULT" == "0" ]]; then
     "$QUIET" || grep -v '^$' "$HTML_TEMP/wattsi-output.txt" # trim blank lines
   fi
 else
+  if [[ "$LOCAL_WATTSI" != true ]]; then
+    "$QUIET" || grep -v '^$' "$HTML_TEMP/wattsi-output.txt" # trim blank lines
+  fi
   if [[ "$WATTSI_RESULT" == "65" ]]; then
     echo
     echo "There were errors. Running again to show the original line numbers."

--- a/build.sh
+++ b/build.sh
@@ -365,8 +365,9 @@ function runWattsi {
   fi
   WATTSI_ARGS+=( "$1" "$2" "$HTML_CACHE/caniuse.json" "$HTML_CACHE/w3cbugs.csv" )
   if hash wattsi 2>/dev/null; then
-    WATTSI_RESULT=$(wattsi "${WATTSI_ARGS[@]}" \
-      > "$HTML_TEMP/wattsi-output.txt"; echo $?)
+    LOCAL_WATTSI=true
+    WATTSI_RESULT="0"
+    wattsi "${WATTSI_ARGS[@]}" || WATTSI_RESULT=$?
   else
     $QUIET || echo
     $QUIET || echo "Local wattsi is not present; trying the build server..."
@@ -410,15 +411,18 @@ function runWattsi {
 
 runWattsi "$HTML_TEMP/source-whatwg-complete" "$HTML_TEMP/wattsi-output"
 if [[ "$WATTSI_RESULT" == "0" ]]; then
+  if [[ "$LOCAL_WATTSI" != true ]]; then
     "$QUIET" || grep -v '^$' "$HTML_TEMP/wattsi-output.txt" # trim blank lines
+  fi
 else
-  grep -v '^$' "$HTML_TEMP/wattsi-output.txt" # trim blank lines
   if [[ "$WATTSI_RESULT" == "65" ]]; then
     echo
     echo "There were errors. Running again to show the original line numbers."
     echo
     runWattsi "$HTML_SOURCE/source" "$HTML_TEMP/wattsi-raw-source-output"
-    grep -v '^$' "$HTML_TEMP/wattsi-output.txt" # trim blank lines
+    if [[ "$LOCAL_WATTSI" != true ]]; then
+      grep -v '^$' "$HTML_TEMP/wattsi-output.txt" # trim blank lines
+    fi
   fi
   echo
   echo "There were errors. Stopping."


### PR DESCRIPTION
This change causes messages from wattsi to get written to the console in real
time as wattsi emits them.

We so far had essentially been buffering output from wattsi — writing the wattsi
output to file and then emitting that after wattsi exited.

The advantage of that was, it allowed for the same output handling as the case
where wattsi is run remotely. The disadvantage was that is prevented us from
watching the progress of wattsi in real time as it runs.

Because wattsi has run relatively quickly — taking on the order of just ~6
seconds from start to finish — the lack of ability to watch wattsi progress in
real time has so far not been a big problem. However, the addition of mechanism
for syntax-highlighting `pre` elements noticeably increases the wattsi
execution time, to the degree that not being able to see messages from wattsi in
real time can make it appear to be hanging.

So this change, along with the “Emit each HTML output filename as it gets written”
change in https://github.com/whatwg/wattsi/pull/63 provides a way to watch the
progress of wattsi in detail as it runs, so we can see exactly what is happening
and when (and know what steps wattsi is running are consuming the most time).