### PR TITLE
Use the new pdfsizeopt verbosity control

### DIFF
--- a/ci-deploy/inside-container.sh
+++ b/ci-deploy/inside-container.sh
@@ -83,9 +83,7 @@ prince --verbose --output "$PDF_TMP" "$PDF_SOURCE_URL"
 
 echo ""
 echo "Optimizing PDF..."
-# Note: `/dev/null 2>&1` mean no output at all, and is a workaround for
-# https://github.com/pts/pdfsizeopt/issues/66
-pdfsizeopt "$PDF_TMP" "$HTML_OUTPUT/print.pdf" > /dev/null 2>&1
+pdfsizeopt --v=40 "$PDF_TMP" "$HTML_OUTPUT/print.pdf"
 
 echo ""
 echo "Deploying PDF..."


### PR DESCRIPTION
--v=40 is errors, warnings and a constant number of info messages
containing progress updates, per the documentation added in
https://github.com/pts/pdfsizeopt/commit/a967c292e62ae69e8da237fce4202097b826f94b