### PR TITLE
Deploy commit snapshots to directories, not files

### DIFF
--- a/ci-deploy/inside-container.sh
+++ b/ci-deploy/inside-container.sh
@@ -54,7 +54,7 @@ echo ""
 echo "Deploying commit snapshot..."
 rsync --rsh="ssh -o UserKnownHostsFile=known_hosts" \
       --archive --compress --verbose \
-      "$HTML_OUTPUT/index.html" "deploy@$SERVER:/var/www/$WEB_ROOT/commit-snapshots/$HTML_SHA"
+      "$HTML_OUTPUT/index.html" "deploy@$SERVER:/var/www/$WEB_ROOT/commit-snapshots/$HTML_SHA/index.html"
 
 echo ""
 echo "Building PDF..."


### PR DESCRIPTION
This matches other WHATWG specs, but more importantly will make it
easier to compress the index.html on disk. With nginx, that requires
an empty index.html and a compressed index.html.gz, and putting them
in directories avoids both being listed in
https://html.spec.whatwg.org/commit-snapshots/, and the compressed
file size showing up as well.

This is a bit weird but WAI in nginx:
https://trac.nginx.org/nginx/ticket/1367