### PR TITLE
Revert "Deploy commit snapshots to directories, not files"

### DIFF
--- a/ci-deploy/inside-container.sh
+++ b/ci-deploy/inside-container.sh
@@ -54,7 +54,7 @@ echo ""
 echo "Deploying commit snapshot..."
 rsync --rsh="ssh -o UserKnownHostsFile=known_hosts" \
       --archive --compress --verbose \
-      "$HTML_OUTPUT/index.html" "deploy@$SERVER:/var/www/$WEB_ROOT/commit-snapshots/$HTML_SHA/index.html"
+      "$HTML_OUTPUT/index.html" "deploy@$SERVER:/var/www/$WEB_ROOT/commit-snapshots/$HTML_SHA"
 
 echo ""
 echo "Building PDF..."


### PR DESCRIPTION
This reverts commit 33a5b3254e91e413dd9819460f47e9b6203a0eb3, as it
breaks the deploy. Closes #136.

I want to un-break builds ASAP so just doing this for now. We can figure out the right fix later.