### PR TITLE
Reland "Deploy commit snapshots to directories, not files"

### DIFF
--- a/ci-deploy/inside-container.sh
+++ b/ci-deploy/inside-container.sh
@@ -45,6 +45,7 @@ echo "$SERVER $SERVER_PUBLIC_KEY" > known_hosts
 
 # Sync, including deletes, but ignoring the commit-snapshots directory so we don't delete that.
 echo "Deploying build output..."
+# --chmod=D755,F644 means read-write for user, read-only for others.
 rsync --rsh="ssh -o UserKnownHostsFile=known_hosts" \
       --archive --chmod=D755,F644 --compress --verbose \
       --delete --exclude="$COMMITS_DIR" \
@@ -57,6 +58,7 @@ mkdir -p "$COMMIT_DIR"
 cp "$HTML_OUTPUT/index.html" "$COMMIT_DIR/"
 echo ""
 echo "Deploying commit snapshot..."
+# --chmod=D755,F644 means read-write for user, read-only for others.
 rsync --rsh="ssh -o UserKnownHostsFile=known_hosts" \
       --archive --chmod=D755,F644 --compress --verbose \
       "$COMMIT_DIR/" "deploy@$SERVER:/var/www/$WEB_ROOT/$COMMITS_DIR/$HTML_SHA"


### PR DESCRIPTION
This relands commit 33a5b3254e91e413dd9819460f47e9b6203a0eb3 with a
different approach which is more similar to the non-HTML
deploy.sh. First create a directory, then rsync that.

This was tested manually with a bogus commit using the live
server. --chmod=D755,F644 was added because the local permissions are
otherwise copied, and there was already some variation on the live
server, both 0644 and 0664 files. That was normalized.