### PR TITLE
Stop deploying .htaccess

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,11 @@ The first time this runs, it will ask for your input on where to clone the HTML 
 
 After you complete the build steps above, the build will run and generate the single-page version of the spec, the multipage version, and more. If all goes well, you should very soon have all the following in your `output/` directory:
 
-- `.htaccess`
 - `404.html`
 - `entities.json`
 - `fonts/*`
 - `images/*`
-- `index`
+- `index.html`
 - `link-fixup.js`
 - `multipage/*`
 

--- a/build.sh
+++ b/build.sh
@@ -443,7 +443,6 @@ mv "$HTML_TEMP/wattsi-output/multipage-html" "$HTML_OUTPUT/multipage"
 mv "$HTML_TEMP/wattsi-output/multipage-dev" "$HTML_OUTPUT/dev"
 rm -rf "$HTML_TEMP"
 
-cp -p  "$HTML_SOURCE/.htaccess" "$HTML_OUTPUT"
 cp -p  "$HTML_SOURCE/404.html" "$HTML_OUTPUT"
 cp -p "$HTML_SOURCE/link-fixup.js" "$HTML_OUTPUT"
 cp -p "$HTML_SOURCE/html-dfn.js" "$HTML_OUTPUT"


### PR DESCRIPTION
This blocks https://github.com/whatwg/html/pull/3292.

Drive-by: index.html now has a file extension