### PR TITLE
Switch from Apache to nginx for build.sh --docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Now you're ready to edit the `html/source` file—and after you make your change
 
 ## Building using a Docker container
 
-The Dockerized version of the build allows you to run the build entirely inside a "container" (lightweight virtual machine). This includes tricky dependencies like a local copy of Wattsi, as well as the Apache HTTP server with a setup analogous to that of https://html.spec.whatwg.org.
+The Dockerized version of the build allows you to run the build entirely inside a "container" (lightweight virtual machine). This includes tricky dependencies like a local copy of Wattsi, as well an HTTP server setup similar to that of https://html.spec.whatwg.org.
 
 To perform a Dockerized build, use the `--docker` flag:
 

--- a/build.sh
+++ b/build.sh
@@ -285,6 +285,7 @@ if [ "$USE_DOCKER" == true ]; then
   fi
 
   docker build "${DOCKER_ARGS[@]}" .
+  echo "Running server on http://localhost:8080"
   docker run --rm -it -p 8080:80 whatwg-html
   exit 0
 fi

--- a/site.conf
+++ b/site.conf
@@ -1,13 +1,4 @@
-<VirtualHost *:80>
-    DocumentRoot /var/www/html
-
-    <Directory "/var/www/html">
-        Options Indexes FollowSymLinks
-        AllowOverride All
-        Require all granted
-    </Directory>
-
-    ErrorLog ${APACHE_LOG_DIR}/error.log
-</VirtualHost>
-
-# vim: syntax=apache ts=4 sw=4 sts=4 sr noet
+server {
+    root /var/www/html;
+    error_log stderr;
+}


### PR DESCRIPTION
Fixes https://github.com/whatwg/html-build/issues/140.

Note that none of the redirects from misc-server are included here,
and weren't before either, in particular /multipage/images/ won't
redirect to /images/. To fix this well the configuration should be
shared, which is a bit of work, and so it's left broken for now.