### PR TITLE
Fix typo causing file-not-found if wattsi error

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -444,7 +444,7 @@ function processSource {
       echo
       echo "There were errors. Running again to show the original line numbers."
       echo
-      runWattsi "$HTML_SOURCE/SOURCE_LOCATION" "$HTML_TEMP/wattsi-raw-source-output"
+      runWattsi "$HTML_SOURCE/$SOURCE_LOCATION" "$HTML_TEMP/wattsi-raw-source-output"
       if [[ "$LOCAL_WATTSI" != true ]]; then
         grep -v '^$' "$HTML_TEMP/wattsi-output.txt" # trim blank lines
       fi


### PR DESCRIPTION
This change fixes a minor regression introduced by a typo in c38c237c
that caused wattsi to fail with a “file not found” message in the case
where some error occurred while parsing the HTML spec source.