### PR TITLE
Lots of refactoring, and some small fixes

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ cd "$(dirname "$0")"
 DIR=$(pwd)
 
 # The latest required version of Wattsi. Update this if you change how ./build.sh invokes Wattsi.
-WATTSI_LATEST=50
+WATTSI_LATEST=56
 
 # Shared state variables throughout this script
 LOCAL_WATTSI=true

--- a/build.sh
+++ b/build.sh
@@ -61,20 +61,7 @@ function main {
     exit 1
   }
 
-  if [[ -d "$HTML_CACHE" ]]; then
-    PREV_BUILD_SHA=$( cat "$HTML_CACHE/last-build-sha.txt" 2>/dev/null || echo )
-    CURRENT_BUILD_SHA=$( git rev-parse HEAD )
-
-    if [[ $PREV_BUILD_SHA != "$CURRENT_BUILD_SHA" ]]; then
-      $QUIET || echo "Build tools have been updated since last run; clearing the cache..."
-      DO_UPDATE=true
-      rm -rf "$HTML_CACHE"
-      mkdir -p "$HTML_CACHE"
-      echo "$CURRENT_BUILD_SHA" > "$HTML_CACHE/last-build-sha.txt"
-    fi
-  else
-    mkdir -p "$HTML_CACHE"
-  fi
+  clearCacheIfNecessary
 
   CURL_ARGS=()
   if ! $VERBOSE; then
@@ -420,6 +407,27 @@ function doDockerBuild {
   docker build "${DOCKER_ARGS[@]}" .
   echo "Running server on http://localhost:8080"
   docker run --rm -it -p 8080:80 whatwg-html
+}
+
+# Clears the $HTML_CACHE directory if the build tools have been updated since last run.
+# Arguments: none
+# Output:
+# - $HTML_CACHE will be usable (possibly empty)
+function clearCacheIfNecessary {
+  if [[ -d "$HTML_CACHE" ]]; then
+    PREV_BUILD_SHA=$( cat "$HTML_CACHE/last-build-sha.txt" 2>/dev/null || echo )
+    CURRENT_BUILD_SHA=$( git rev-parse HEAD )
+
+    if [[ $PREV_BUILD_SHA != "$CURRENT_BUILD_SHA" ]]; then
+      $QUIET || echo "Build tools have been updated since last run; clearing the cache..."
+      DO_UPDATE=true
+      rm -rf "$HTML_CACHE"
+      mkdir -p "$HTML_CACHE"
+      echo "$CURRENT_BUILD_SHA" > "$HTML_CACHE/last-build-sha.txt"
+    fi
+  else
+    mkdir -p "$HTML_CACHE"
+  fi
 }
 
 # Performs a build of the HTML source file into the resulting output

--- a/build.sh
+++ b/build.sh
@@ -105,32 +105,7 @@ function main {
     fi
   fi
 
-  $QUIET || echo "Looking for the HTML source (set HTML_SOURCE to override)..."
-  if [[ $HTML_SOURCE == "" ]]; then
-    PARENT_DIR=$(dirname "$DIR")
-    if [[ -f "$PARENT_DIR/html/source" ]]; then
-      HTML_SOURCE=$PARENT_DIR/html
-      $QUIET || echo "Found $HTML_SOURCE (alongside html-build)..."
-    else
-      if [[ -f "$DIR/html/source" ]]; then
-        HTML_SOURCE=$DIR/html
-        $QUIET || echo "Found $HTML_SOURCE (inside html-build)..."
-      else
-        $QUIET || echo "Didn't find the HTML source on your system..."
-        chooseRepo
-      fi
-    fi
-  else
-    if [[ -f "$HTML_SOURCE/source" ]]; then
-      $QUIET || echo "Found $HTML_SOURCE (from HTML_SOURCE)..."
-    else
-      $QUIET || echo "Looked in the $HTML_SOURCE directory but didn't find HTML source there..."
-      HTML_SOURCE=""
-      chooseRepo
-    fi
-  fi
-
-  export HTML_SOURCE
+  findHTMLSource
 
   HTML_GIT_DIR="$HTML_SOURCE/.git/"
   HTML_SHA=${SHA_OVERRIDE:-$(git --git-dir="$HTML_GIT_DIR" rev-parse HEAD)}
@@ -238,6 +213,44 @@ function main {
   $QUIET || echo "Success!"
 }
 
+# Finds the location of the HTML Standard, and stores it in the HTML_SOURCE variable.
+# It either guesses based on directory structure, or interactively prompts the user.
+# - Arguments: none
+# - Output:
+#   - Sets $HTML_SOURCE
+function findHTMLSource {
+  $QUIET || echo "Looking for the HTML source (set HTML_SOURCE to override)..."
+  if [[ $HTML_SOURCE == "" ]]; then
+    PARENT_DIR=$(dirname "$DIR")
+    if [[ -f "$PARENT_DIR/html/source" ]]; then
+      HTML_SOURCE=$PARENT_DIR/html
+      $QUIET || echo "Found $HTML_SOURCE (alongside html-build)..."
+    else
+      if [[ -f "$DIR/html/source" ]]; then
+        HTML_SOURCE=$DIR/html
+        $QUIET || echo "Found $HTML_SOURCE (inside html-build)..."
+      else
+        $QUIET || echo "Didn't find the HTML source on your system..."
+        chooseRepo
+      fi
+    fi
+  else
+    if [[ -f "$HTML_SOURCE/source" ]]; then
+      $QUIET || echo "Found $HTML_SOURCE (from HTML_SOURCE)..."
+    else
+      $QUIET || echo "Looked in the $HTML_SOURCE directory but didn't find HTML source there..."
+      HTML_SOURCE=""
+      chooseRepo
+    fi
+  fi
+
+  export HTML_SOURCE
+}
+
+# Interactively prompts the user for where their HTML source file is.
+# - Arguments: none
+# - Output:
+#   - Sets $HTML_SOURCE
 function chooseRepo {
   echo
   echo "What HTML source would you like to build from?"
@@ -296,6 +309,10 @@ function chooseRepo {
   fi
 }
 
+# Confirms the currently-set HTML_SOURCE with the user, or clones HTML_REPO into HTML_SOURCE
+# - Arguments: none
+# - Output:
+#   - $HTML_SOURCE will now point to a folder containing the HTML Standard
 function confirmRepo {
   if [[ $HTML_SOURCE != "" ]]; then
     if [[ -f "$HTML_SOURCE/source" ]]; then
@@ -337,10 +354,14 @@ function confirmRepo {
   fi
 }
 
+# Gives the relative path to $2 from $1
 # From http://stackoverflow.com/a/12498485
+# - Arguments:
+#   - $1: absolute path beginning with /
+#   - $2: absolute path beginning with /
+# - Output:
+#   - Echoes the relative path
 function relativePath {
-  # both $1 and $2 are absolute paths beginning with /
-  # returns relative path to $2 from $1
   local source=$1
   local target=$2
 
@@ -379,6 +400,12 @@ function relativePath {
   echo "$result"
 }
 
+# Performs a build of the HTML source file into the resulting output
+# - Arguments:
+#   - $1: the filename of the source file within HTML_SOURCE (e.g. "source")
+#   - $2: the build type, either "default" or "review"
+# - Output:
+#   - $HTML_OUTPUT will contain the built files
 function processSource {
   rm -rf "$HTML_TEMP" && mkdir -p "$HTML_TEMP"
 
@@ -456,14 +483,15 @@ Disallow: /review-drafts/" > "$HTML_OUTPUT/robots.txt"
   fi
 }
 
+# Runs Wattsi on the given file, either locally or using the web service
+# - Arguments:
+#   - $1: the file to run Wattsi on
+#   - $2: the directory for Wattsi to write output to
+# - Output:
+#   - Sets $WATTSI_RESULT to the exit code
+#   - $HTML_TEMP/wattsi-output directory will contain the output from Wattsi on success
+#   - $HTML_TEMP/wattsi-output.txt will contain the output from Wattsi, on both success and failure
 function runWattsi {
-  # Input arguments: $1 is the file to run wattsi on, $2 is a directory for wattsi to write output
-  # to
-  # Output:
-  # - Sets global variable $WATTSI_RESULT to an exit code (or equivalent, for HTTP version)
-  # - $HTML_TEMP/wattsi-output directory will contain the output from wattsi on success
-  # - $HTML_TEMP/wattsi-output.txt will contain the output from wattsi, on both success and failure
-
   rm -rf "$2"
   mkdir "$2"
 
@@ -525,6 +553,12 @@ function runWattsi {
   fi
 }
 
+# Runs backlink generation post-processing on the output of Wattsi
+# Arguments:
+# - $1: the spec variant (e.g. "snap" or "html") to run on
+# - $2: The destination directory for the output file
+# Output:
+# - $2 will contain an index.html file derived from the given variant, with post-processing applied
 function generateBacklinks {
   perl .post-process-partial-backlink-generator.pl "$HTML_TEMP/wattsi-output/index-$1" > "$2/index.html";
 }

--- a/build.sh
+++ b/build.sh
@@ -78,7 +78,7 @@ function main {
 
   # $SKIP_BUILD_UPDATE_CHECK is set inside the Dockerfile so that we don't check for updates both inside and outside
   # the Docker container.
-  if [[ "$DO_UPDATE" == true && "$SKIP_BUILD_UPDATE_CHECK" != true ]]; then
+  if [[ $DO_UPDATE == "true" && $SKIP_BUILD_UPDATE_CHECK != "true" ]]; then
     $QUIET || echo "Checking if html-build is up to date..."
     GIT_FETCH_ARGS=()
     if ! $VERBOSE ; then
@@ -89,10 +89,10 @@ function main {
     GIT_FETCH_ARGS+=( "$ORIGIN_URL" master)
     git fetch "${GIT_FETCH_ARGS[@]}"
     NEW_COMMITS=$(git rev-list --count HEAD..FETCH_HEAD)
-    if [ "$NEW_COMMITS" != "0" ]; then
+    if [[ $NEW_COMMITS != "0" ]]; then
       $QUIET || echo
       echo -n "Your local branch is $NEW_COMMITS "
-      [ "$NEW_COMMITS" == "1" ] && echo -n commit || echo -n commits
+      [[ $NEW_COMMITS == "1" ]] && echo -n "commit" || echo -n "commits"
       echo " behind $ORIGIN_URL:"
       git log --oneline HEAD..FETCH_HEAD
       echo
@@ -106,13 +106,13 @@ function main {
   fi
 
   $QUIET || echo "Looking for the HTML source (set HTML_SOURCE to override)..."
-  if [[ "$HTML_SOURCE" == "" ]]; then
+  if [[ $HTML_SOURCE == "" ]]; then
     PARENT_DIR=$(dirname "$DIR")
-    if [ -f "$PARENT_DIR/html/source" ]; then
+    if [[ -f "$PARENT_DIR/html/source" ]]; then
       HTML_SOURCE=$PARENT_DIR/html
       $QUIET || echo "Found $HTML_SOURCE (alongside html-build)..."
     else
-      if [ -f "$DIR/html/source" ]; then
+      if [[ -f "$DIR/html/source" ]]; then
         HTML_SOURCE=$DIR/html
         $QUIET || echo "Found $HTML_SOURCE (inside html-build)..."
       else
@@ -121,7 +121,7 @@ function main {
       fi
     fi
   else
-    if [ -f "$HTML_SOURCE/source" ]; then
+    if [[ -f "$HTML_SOURCE/source" ]]; then
       $QUIET || echo "Found $HTML_SOURCE (from HTML_SOURCE)..."
     else
       $QUIET || echo "Looked in the $HTML_SOURCE directory but didn't find HTML source there..."
@@ -135,8 +135,8 @@ function main {
   HTML_GIT_DIR="$HTML_SOURCE/.git/"
   HTML_SHA=${SHA_OVERRIDE:-$(git --git-dir="$HTML_GIT_DIR" rev-parse HEAD)}
 
-  if [ "$USE_DOCKER" == true ]; then
-    if [[ "$HTML_SOURCE" != $(pwd)/* ]]; then
+  if [[ $USE_DOCKER == "true" ]]; then
+    if [[ $HTML_SOURCE != $(pwd)/* ]]; then # intentionally not quoting the RHS; we want expansion
       echo "When using Docker, the HTML source must be checked out in a subdirectory of the html-build repo. Cannot continue."
       exit 1
     fi
@@ -174,11 +174,11 @@ function main {
     exit 1
   }
 
-  if [ -d "$HTML_CACHE" ]; then
+  if [[ -d "$HTML_CACHE" ]]; then
     PREV_BUILD_SHA=$( cat "$HTML_CACHE/last-build-sha.txt" 2>/dev/null || echo )
     CURRENT_BUILD_SHA=$( git rev-parse HEAD )
 
-    if [ "$PREV_BUILD_SHA" != "$CURRENT_BUILD_SHA" ]; then
+    if [[ $PREV_BUILD_SHA != "$CURRENT_BUILD_SHA" ]]; then
       $QUIET || echo "Build tools have been updated since last run; clearing the cache..."
       DO_UPDATE=true
       rm -rf "$HTML_CACHE"
@@ -197,14 +197,14 @@ function main {
   CURL_CANIUSE_ARGS=( "${CURL_ARGS[@]}" --output "$HTML_CACHE/caniuse.json" -k )
   CURL_W3CBUGS_ARGS=( "${CURL_ARGS[@]}" --output "$HTML_CACHE/w3cbugs.csv" )
 
-  if [[ "$DO_UPDATE" == true || ! -f "$HTML_CACHE/caniuse.json" ]]; then
+  if [[ $DO_UPDATE == "true" || ! -f "$HTML_CACHE/caniuse.json" ]]; then
     rm -f "$HTML_CACHE/caniuse.json"
     $QUIET || echo "Downloading caniuse data..."
     curl "${CURL_CANIUSE_ARGS[@]}" \
       https://raw.githubusercontent.com/Fyrd/caniuse/master/data.json
   fi
 
-  if [[ "$DO_UPDATE" == true || ! -f "$HTML_CACHE/w3cbugs.csv" ]]; then
+  if [[ $DO_UPDATE == "true" || ! -f "$HTML_CACHE/w3cbugs.csv" ]]; then
     rm -f "$HTML_CACHE/w3cbugs.csv"
     $QUIET || echo "Downloading list of W3C bugzilla bugs..."
     curl "${CURL_W3CBUGS_ARGS[@]}" \
@@ -249,28 +249,28 @@ function chooseRepo {
   echo "5) Quit"
   echo
   read -r -e -p "Choose 1-5: " choice
-  if [ "1" = "$choice" ]; then
+  if [[ $choice == "1" ]]; then
     read -r -e -p "Path to your existing clone: "
     HTML_SOURCE=$(echo "$REPLY" | xargs) # trims leading/trailing space
-    if [[ "$HTML_SOURCE" = "" ]]; then
+    if [[ $HTML_SOURCE = "" ]]; then
       chooseRepo
     fi
     confirmRepo
-  elif [ "2" = "$choice" ]; then
+  elif [[ $choice == "2" ]]; then
     HTML_REPO=https://github.com/whatwg/html.git
     confirmRepo
-  elif [ "3" = "$choice" ]; then
+  elif [[ $choice == "3" ]]; then
     echo
     read -r -e -p "GitHub username of fork owner: "
     GH_USERNAME=$(echo "$REPLY" | xargs) # trims leading/trailing space
-    if [ -z "$GH_USERNAME" ]; then
+    if [[ $GH_USERNAME == "" ]]; then
       chooseRepo
     fi
     echo
     echo "Does a fork already exist at https://github.com/$GH_USERNAME/html?"
     echo
     read -r -e -p "Y or N? " yn
-    if [[ "y" = "$yn" || "Y" = "$yn" ]]; then
+    if [[ $yn == "y" || $yn == "Y" ]]; then
       HTML_REPO="https://github.com/$GH_USERNAME/html.git"
       confirmRepo
     else
@@ -278,16 +278,16 @@ function chooseRepo {
       echo "Before proceeding, first go to https://github.com/whatwg/html and create a fork."
       exit
     fi
-  elif [ "4" = "$choice" ]; then
+  elif [[ $choice == "4" ]]; then
     echo
     read -r -e -p "URL: "
     REPLY=$(echo "$REPLY" | xargs) # trims leading/trailing space
-    if [ -z "$REPLY" ]; then
+    if [[ $REPLY == "" ]]; then
       chooseRepo
     fi
     HTML_REPO=$REPLY
     confirmRepo
-  elif [[ "5" = "$choice" || "q" = "$choice" || "Q" = "$choice" ]]; then
+  elif [[ $choice == "5" || $choice == "q" || $choice == "Q" ]]; then
     echo
     echo "Can't build without a source repo to build from. Quitting..."
     exit
@@ -297,13 +297,13 @@ function chooseRepo {
 }
 
 function confirmRepo {
-  if [[ "$HTML_SOURCE" != "" ]]; then
-    if [ -f "$HTML_SOURCE/source" ]; then
+  if [[ $HTML_SOURCE != "" ]]; then
+    if [[ -f "$HTML_SOURCE/source" ]]; then
       echo
       echo "OK, build from the $HTML_SOURCE/source file?"
       echo
       read -r -e -p "Y or N? " yn
-      if [[ "y" = "$yn" || "Y" = "$yn" ]]; then
+      if [[ $yn == "y" || $yn == "Y" ]]; then
         return
       else
         HTML_SOURCE=""
@@ -329,7 +329,7 @@ function confirmRepo {
     GIT_CLONE_ARGS+=( --quiet )
   fi
   GIT_CLONE_ARGS+=( "$HTML_REPO" "$HTML_SOURCE" )
-  if [[ "y" = "$yn" || "Y" = "$yn" ]]; then
+  if [[ $yn == "y" || $yn == "Y" ]]; then
     git clone "${GIT_CLONE_ARGS[@]}"
   else
     HTML_SOURCE=""
@@ -352,7 +352,7 @@ function relativePath {
     # go up one level (reduce common part)
     commonPart=$(dirname "$commonPart")
     # and record that we went back, with correct / handling
-    if [[ -z $result ]]; then
+    if [[ $result == "" ]]; then
       result=".."
     else
       result="../$result"
@@ -369,9 +369,9 @@ function relativePath {
   local forwardPart="${target#$commonPart}"
 
   # and now stick all parts together
-  if [[ -n $result ]] && [[ -n $forwardPart ]]; then
+  if [[ $result != "" ]] && [[ $forwardPart != "" ]]; then
     result="$result$forwardPart"
-  elif [[ -n $forwardPart ]]; then
+  elif [[ $forwardPart != "" ]]; then
     # extra slash removal
     result="${forwardPart:1}"
   fi
@@ -397,20 +397,20 @@ function processSource {
   perl .pre-process-tag-omission.pl < "$HTML_TEMP/source-expanded-2" | perl .pre-process-index-generator.pl > "$HTML_TEMP/source-whatwg-complete" # this one could be merged
 
   runWattsi "$HTML_TEMP/source-whatwg-complete" "$HTML_TEMP/wattsi-output"
-  if [[ "$WATTSI_RESULT" == "0" ]]; then
-    if [[ "$LOCAL_WATTSI" != true ]]; then
+  if [[ $WATTSI_RESULT == "0" ]]; then
+    if [[ $LOCAL_WATTSI != "true" ]]; then
       "$QUIET" || grep -v '^$' "$HTML_TEMP/wattsi-output.txt" # trim blank lines
     fi
   else
-    if [[ "$LOCAL_WATTSI" != true ]]; then
+    if [[ $LOCAL_WATTSI != "true" ]]; then
       "$QUIET" || grep -v '^$' "$HTML_TEMP/wattsi-output.txt" # trim blank lines
     fi
-    if [[ "$WATTSI_RESULT" == "65" ]]; then
+    if [[ $WATTSI_RESULT == "65" ]]; then
       echo
       echo "There were errors. Running again to show the original line numbers."
       echo
       runWattsi "$HTML_SOURCE/$SOURCE_LOCATION" "$HTML_TEMP/wattsi-raw-source-output"
-      if [[ "$LOCAL_WATTSI" != true ]]; then
+      if [[ $LOCAL_WATTSI != "true" ]]; then
         grep -v '^$' "$HTML_TEMP/wattsi-output.txt" # trim blank lines
       fi
     fi
@@ -419,7 +419,7 @@ function processSource {
     exit "$WATTSI_RESULT"
   fi
 
-  if [[ "$BUILD_TYPE" == "default" ]]; then
+  if [[ $BUILD_TYPE == "default" ]]; then
     # Singlepage HTML
     generateBacklinks "html" "$HTML_OUTPUT";
 
@@ -473,7 +473,7 @@ function runWattsi {
   fi
   WATTSI_ARGS+=( "$1" "$HTML_SHA" "$2" "$BUILD_TYPE" "$HTML_CACHE/caniuse.json" "$HTML_CACHE/w3cbugs.csv")
   if hash wattsi 2>/dev/null; then
-    if [ "$(wattsi --version | cut -d' ' -f2)" -lt "$WATTSI_LATEST" ]; then
+    if [[ "$(wattsi --version | cut -d' ' -f2)" -lt "$WATTSI_LATEST" ]]; then
       echo
       echo "Warning: Your wattsi version is out of date. You should to rebuild an"
       echo "up-to-date wattsi binary from the wattsi sources."
@@ -504,13 +504,13 @@ function runWattsi {
     # read exit code from the Wattsi-Exit-Code header and assume failure if not found
     WATTSI_RESULT=1
     while IFS=":" read -r NAME VALUE; do
-      if [ "$NAME" == "Wattsi-Exit-Code" ]; then
+      if [[ $NAME == "Wattsi-Exit-Code" ]]; then
         WATTSI_RESULT=$(echo "$VALUE" | tr -d ' \r\n')
         break
       fi
     done < "$HTML_TEMP/wattsi-headers.txt"
 
-    if [ "$WATTSI_RESULT" != "0" ]; then
+    if [[ $WATTSI_RESULT != "0" ]]; then
       mv "$HTML_TEMP/wattsi-output.zip" "$HTML_TEMP/wattsi-output.txt"
     else
       UNZIP_ARGS=()

--- a/build.sh
+++ b/build.sh
@@ -35,46 +35,7 @@ SKIP_BUILD_UPDATE_CHECK=${SKIP_BUILD_UPDATE_CHECK:-false}
 SHA_OVERRIDE=${SHA_OVERRIDE:-}
 
 function main {
-  for arg in "$@"
-  do
-    case $arg in
-      -c|--clean)
-        rm -rf "$HTML_CACHE"
-        exit 0
-        ;;
-      -h|--help)
-        echo "Usage: $0 [-c|--clean]"
-        echo "       $0 [-h|--help]"
-        echo "       $0 [-d|--docker]"
-        echo "       $0 [-n|--no-update] [-p|--no-post] [-q|--quiet] [-v|--verbose]"
-        echo
-        echo "  -c|--clean      Remove downloaded dependencies and generated files (then stop)."
-        echo "  -h|--help       Show this usage statement."
-        echo "  -n|--no-update  Don't update before building; just build."
-        echo "  -d|--docker     Use Docker to build in and serve from a container."
-        echo "  -q|--quiet      Don't emit any messages except errors/warnings."
-        echo "  -v|--verbose    Show verbose output from every build step."
-        exit 0
-        ;;
-      -n|--no-update|--no-updates)
-        DO_UPDATE=false
-        ;;
-      -d|--docker)
-        USE_DOCKER=true
-        ;;
-      -q|--quiet)
-        QUIET=true
-        VERBOSE=false
-        ;;
-      -v|--verbose)
-        VERBOSE=true
-        QUIET=false
-        set -vx
-        ;;
-      *)
-        ;;
-    esac
-  done
+  processCommandLineArgs "$@"
 
   # $SKIP_BUILD_UPDATE_CHECK is set inside the Dockerfile so that we don't check for updates both inside and outside
   # the Docker container.
@@ -211,6 +172,54 @@ function main {
 
   $QUIET || echo
   $QUIET || echo "Success!"
+}
+
+# Processes incoming command-line arguments
+# Arguments: all arguments to this shell script
+# Output:
+# - If the clean or help commands are given, perform them
+# - Otherwise, sets the $DO_UPDATE, $USE_DOCKER, $QUIET, and $VERBOSE variables appropriately
+function processCommandLineArgs {
+  for arg in "$@"
+  do
+    case $arg in
+      -c|--clean)
+        rm -rf "$HTML_CACHE"
+        exit 0
+        ;;
+      -h|--help)
+        echo "Usage: $0 [-c|--clean]"
+        echo "       $0 [-h|--help]"
+        echo "       $0 [-d|--docker]"
+        echo "       $0 [-n|--no-update] [-p|--no-post] [-q|--quiet] [-v|--verbose]"
+        echo
+        echo "  -c|--clean      Remove downloaded dependencies and generated files (then stop)."
+        echo "  -h|--help       Show this usage statement."
+        echo "  -n|--no-update  Don't update before building; just build."
+        echo "  -d|--docker     Use Docker to build in and serve from a container."
+        echo "  -q|--quiet      Don't emit any messages except errors/warnings."
+        echo "  -v|--verbose    Show verbose output from every build step."
+        exit 0
+        ;;
+      -n|--no-update|--no-updates)
+        DO_UPDATE=false
+        ;;
+      -d|--docker)
+        USE_DOCKER=true
+        ;;
+      -q|--quiet)
+        QUIET=true
+        VERBOSE=false
+        ;;
+      -v|--verbose)
+        VERBOSE=true
+        QUIET=false
+        set -vx
+        ;;
+      *)
+        ;;
+    esac
+  done
 }
 
 # Finds the location of the HTML Standard, and stores it in the HTML_SOURCE variable.

--- a/build.sh
+++ b/build.sh
@@ -183,20 +183,19 @@ function processCommandLineArgs {
   for arg in "$@"
   do
     case $arg in
-      -c|--clean)
+      clean)
         rm -rf "$HTML_CACHE"
         exit 0
         ;;
-      -h|--help)
-        echo "Usage: $0 [-c|--clean]"
-        echo "       $0 [-h|--help]"
-        echo "       $0 [-d|--docker]"
-        echo "       $0 [-n|--no-update] [-p|--no-post] [-q|--quiet] [-v|--verbose]"
+      help)
+        echo "Commands:"
+        echo "  $0        Build the HTML Standard."
+        echo "  $0 clean  Remove downloaded dependencies and generated files (then stop)."
+        echo "  $0 help   Show this usage statement."
         echo
-        echo "  -c|--clean      Remove downloaded dependencies and generated files (then stop)."
-        echo "  -h|--help       Show this usage statement."
-        echo "  -n|--no-update  Don't update before building; just build."
+        echo "Build options:"
         echo "  -d|--docker     Use Docker to build in and serve from a container."
+        echo "  -n|--no-update  Don't update before building; just build."
         echo "  -q|--quiet      Don't emit any messages except errors/warnings."
         echo "  -v|--verbose    Show verbose output from every build step."
         exit 0

--- a/build.sh
+++ b/build.sh
@@ -40,30 +40,7 @@ function main {
   # $SKIP_BUILD_UPDATE_CHECK is set inside the Dockerfile so that we don't check for updates both inside and outside
   # the Docker container.
   if [[ $DO_UPDATE == "true" && $SKIP_BUILD_UPDATE_CHECK != "true" ]]; then
-    $QUIET || echo "Checking if html-build is up to date..."
-    GIT_FETCH_ARGS=()
-    if ! $VERBOSE ; then
-      GIT_FETCH_ARGS+=( --quiet )
-    fi
-    # TODO: `git remote get-url origin` is nicer, but new in Git 2.7.
-    ORIGIN_URL=$(git config --get remote.origin.url)
-    GIT_FETCH_ARGS+=( "$ORIGIN_URL" master)
-    git fetch "${GIT_FETCH_ARGS[@]}"
-    NEW_COMMITS=$(git rev-list --count HEAD..FETCH_HEAD)
-    if [[ $NEW_COMMITS != "0" ]]; then
-      $QUIET || echo
-      echo -n "Your local branch is $NEW_COMMITS "
-      [[ $NEW_COMMITS == "1" ]] && echo -n "commit" || echo -n "commits"
-      echo " behind $ORIGIN_URL:"
-      git log --oneline HEAD..FETCH_HEAD
-      echo
-      echo "To update, run this command:"
-      echo
-      echo "  git pull --rebase origin master"
-      echo
-      echo "This check can be bypassed with the --no-update option."
-      exit 1
-    fi
+    checkHTMLBuildIsUpToDate
   fi
 
   findHTMLSource
@@ -219,6 +196,36 @@ function processCommandLineArgs {
         ;;
     esac
   done
+}
+
+# Checks if the html-build repository is up to date
+# Arguments: none
+# Output: will tell the user and exit the script with code 1 if not up to date
+function checkHTMLBuildIsUpToDate {
+  $QUIET || echo "Checking if html-build is up to date..."
+  GIT_FETCH_ARGS=()
+  if ! $VERBOSE ; then
+    GIT_FETCH_ARGS+=( --quiet )
+  fi
+  # TODO: `git remote get-url origin` is nicer, but new in Git 2.7.
+  ORIGIN_URL=$(git config --get remote.origin.url)
+  GIT_FETCH_ARGS+=( "$ORIGIN_URL" master)
+  git fetch "${GIT_FETCH_ARGS[@]}"
+  NEW_COMMITS=$(git rev-list --count HEAD..FETCH_HEAD)
+  if [[ $NEW_COMMITS != "0" ]]; then
+    $QUIET || echo
+    echo -n "Your local branch is $NEW_COMMITS "
+    [[ $NEW_COMMITS == "1" ]] && echo -n "commit" || echo -n "commits"
+    echo " behind $ORIGIN_URL:"
+    git log --oneline HEAD..FETCH_HEAD
+    echo
+    echo "To update, run this command:"
+    echo
+    echo "  git pull --rebase origin master"
+    echo
+    echo "This check can be bypassed with the --no-update option."
+    exit 1
+  fi
 }
 
 # Finds the location of the HTML Standard, and stores it in the HTML_SOURCE variable.

--- a/build.sh
+++ b/build.sh
@@ -49,33 +49,7 @@ function main {
   HTML_SHA=${SHA_OVERRIDE:-$(git --git-dir="$HTML_GIT_DIR" rev-parse HEAD)}
 
   if [[ $USE_DOCKER == "true" ]]; then
-    if [[ $HTML_SOURCE != $(pwd)/* ]]; then # intentionally not quoting the RHS; we want expansion
-      echo "When using Docker, the HTML source must be checked out in a subdirectory of the html-build repo. Cannot continue."
-      exit 1
-    fi
-
-    # $SOURCE_RELATIVE helps on Windows with Git Bash, where /c/... is a symlink, which Docker doesn't like.
-    SOURCE_RELATIVE=$(relativePath "$(pwd)" "$HTML_SOURCE")
-
-    VERBOSE_OR_QUIET_FLAG=""
-    $QUIET && VERBOSE_OR_QUIET_FLAG+="--quiet"
-    $VERBOSE && VERBOSE_OR_QUIET_FLAG+="--verbose"
-
-    NO_UPDATE_FLAG="--no-update"
-    $DO_UPDATE && NO_UPDATE_FLAG=""
-
-    DOCKER_ARGS=( --tag whatwg-html \
-                  --build-arg "html_source_dir=$SOURCE_RELATIVE" \
-                  --build-arg "verbose_or_quiet_flag=$VERBOSE_OR_QUIET_FLAG" \
-                  --build-arg "no_update_flag=$NO_UPDATE_FLAG" \
-                  --build-arg "sha_override=$HTML_SHA" )
-    if $QUIET; then
-      DOCKER_ARGS+=( --quiet )
-    fi
-
-    docker build "${DOCKER_ARGS[@]}" .
-    echo "Running server on http://localhost:8080"
-    docker run --rm -it -p 8080:80 whatwg-html
+    doDockerBuild
     exit 0
   fi
 
@@ -413,6 +387,39 @@ function relativePath {
   fi
 
   echo "$result"
+}
+
+# Performs the build using Docker, essentially running this script again inside the container.
+# Arguments: none
+# Output: A web server with the build output will be running inside the Docker container
+function doDockerBuild {
+  if [[ $HTML_SOURCE != $(pwd)/* ]]; then
+    echo "When using Docker, the HTML source must be checked out in a subdirectory of the html-build repo. Cannot continue."
+    exit 1
+  fi
+
+  # $SOURCE_RELATIVE helps on Windows with Git Bash, where /c/... is a symlink, which Docker doesn't like.
+  SOURCE_RELATIVE=$(relativePath "$(pwd)" "$HTML_SOURCE")
+
+  VERBOSE_OR_QUIET_FLAG=""
+  $QUIET && VERBOSE_OR_QUIET_FLAG+="--quiet"
+  $VERBOSE && VERBOSE_OR_QUIET_FLAG+="--verbose"
+
+  NO_UPDATE_FLAG="--no-update"
+  $DO_UPDATE && NO_UPDATE_FLAG=""
+
+  DOCKER_ARGS=( --tag whatwg-html \
+                --build-arg "html_source_dir=$SOURCE_RELATIVE" \
+                --build-arg "verbose_or_quiet_flag=$VERBOSE_OR_QUIET_FLAG" \
+                --build-arg "no_update_flag=$NO_UPDATE_FLAG" \
+                --build-arg "sha_override=$HTML_SHA" )
+  if $QUIET; then
+    DOCKER_ARGS+=( --quiet )
+  fi
+
+  docker build "${DOCKER_ARGS[@]}" .
+  echo "Running server on http://localhost:8080"
+  docker run --rm -it -p 8080:80 whatwg-html
 }
 
 # Performs a build of the HTML source file into the resulting output

--- a/build.sh
+++ b/build.sh
@@ -63,27 +63,7 @@ function main {
 
   clearCacheIfNecessary
 
-  CURL_ARGS=()
-  if ! $VERBOSE; then
-    CURL_ARGS+=( --silent )
-  fi
-
-  CURL_CANIUSE_ARGS=( "${CURL_ARGS[@]}" --output "$HTML_CACHE/caniuse.json" -k )
-  CURL_W3CBUGS_ARGS=( "${CURL_ARGS[@]}" --output "$HTML_CACHE/w3cbugs.csv" )
-
-  if [[ $DO_UPDATE == "true" || ! -f "$HTML_CACHE/caniuse.json" ]]; then
-    rm -f "$HTML_CACHE/caniuse.json"
-    $QUIET || echo "Downloading caniuse data..."
-    curl "${CURL_CANIUSE_ARGS[@]}" \
-      https://raw.githubusercontent.com/Fyrd/caniuse/master/data.json
-  fi
-
-  if [[ $DO_UPDATE == "true" || ! -f "$HTML_CACHE/w3cbugs.csv" ]]; then
-    rm -f "$HTML_CACHE/w3cbugs.csv"
-    $QUIET || echo "Downloading list of W3C bugzilla bugs..."
-    curl "${CURL_W3CBUGS_ARGS[@]}" \
-      'https://www.w3.org/Bugs/Public/buglist.cgi?columnlist=bug_file_loc,short_desc&query_format=advanced&resolution=---&ctype=csv&status_whiteboard=whatwg-resolved&status_whiteboard_type=notregexp&bug_file_loc=http&bug_file_loc_type=substring&product=WHATWG&product=HTML%20WG&product=CSS&product=WebAppsWG'
-  fi
+  updateRemoteDataFiles
 
   rm -rf "$HTML_OUTPUT" && mkdir -p "$HTML_OUTPUT"
   # Set these up so rsync will not complain about either being missing
@@ -427,6 +407,34 @@ function clearCacheIfNecessary {
     fi
   else
     mkdir -p "$HTML_CACHE"
+  fi
+}
+
+# Updates the caniuse.json and w3cbugs.csv files, if either $DO_UPDATE is true or they are not yet cached.
+# Arguments: none
+# Output:
+# - $HTML_CACHE will contain usable caniuse.json and w3cbugs.csv files
+function updateRemoteDataFiles {
+  CURL_ARGS=()
+  if ! $VERBOSE; then
+    CURL_ARGS+=( --silent )
+  fi
+
+  CURL_CANIUSE_ARGS=( "${CURL_ARGS[@]}" --output "$HTML_CACHE/caniuse.json" -k )
+  CURL_W3CBUGS_ARGS=( "${CURL_ARGS[@]}" --output "$HTML_CACHE/w3cbugs.csv" )
+
+  if [[ $DO_UPDATE == "true" || ! -f "$HTML_CACHE/caniuse.json" ]]; then
+    rm -f "$HTML_CACHE/caniuse.json"
+    $QUIET || echo "Downloading caniuse data..."
+    curl "${CURL_CANIUSE_ARGS[@]}" \
+      https://raw.githubusercontent.com/Fyrd/caniuse/master/data.json
+  fi
+
+  if [[ $DO_UPDATE == "true" || ! -f "$HTML_CACHE/w3cbugs.csv" ]]; then
+    rm -f "$HTML_CACHE/w3cbugs.csv"
+    $QUIET || echo "Downloading list of W3C bugzilla bugs..."
+    curl "${CURL_W3CBUGS_ARGS[@]}" \
+      'https://www.w3.org/Bugs/Public/buglist.cgi?columnlist=bug_file_loc,short_desc&query_format=advanced&resolution=---&ctype=csv&status_whiteboard=whatwg-resolved&status_whiteboard_type=notregexp&bug_file_loc=http&bug_file_loc_type=substring&product=WHATWG&product=HTML%20WG&product=CSS&product=WebAppsWG'
   fi
 }
 

--- a/build.sh
+++ b/build.sh
@@ -27,75 +27,208 @@ export HTML_OUTPUT
 
 SHA_OVERRIDE=${SHA_OVERRIDE:-}
 
-for arg in "$@"
-do
-  case $arg in
-    -c|--clean)
-      rm -rf "$HTML_CACHE"
-      exit 0
-      ;;
-    -h|--help)
-      echo "Usage: $0 [-c|--clean]"
-      echo "       $0 [-h|--help]"
-      echo "       $0 [-d|--docker]"
-      echo "       $0 [-n|--no-update] [-p|--no-post] [-q|--quiet] [-v|--verbose]"
-      echo
-      echo "  -c|--clean      Remove downloaded dependencies and generated files (then stop)."
-      echo "  -h|--help       Show this usage statement."
-      echo "  -n|--no-update  Don't update before building; just build."
-      echo "  -d|--docker     Use Docker to build in and serve from a container."
-      echo "  -q|--quiet      Don't emit any messages except errors/warnings."
-      echo "  -v|--verbose    Show verbose output from every build step."
-      exit 0
-      ;;
-    -n|--no-update|--no-updates)
-      DO_UPDATE=false
-      ;;
-    -d|--docker)
-      USE_DOCKER=true
-      ;;
-    -q|--quiet)
-      QUIET=true
-      VERBOSE=false
-      ;;
-    -v|--verbose)
-      VERBOSE=true
-      QUIET=false
-      set -vx
-      ;;
-    *)
-      ;;
-  esac
-done
+function main {
+  for arg in "$@"
+  do
+    case $arg in
+      -c|--clean)
+        rm -rf "$HTML_CACHE"
+        exit 0
+        ;;
+      -h|--help)
+        echo "Usage: $0 [-c|--clean]"
+        echo "       $0 [-h|--help]"
+        echo "       $0 [-d|--docker]"
+        echo "       $0 [-n|--no-update] [-p|--no-post] [-q|--quiet] [-v|--verbose]"
+        echo
+        echo "  -c|--clean      Remove downloaded dependencies and generated files (then stop)."
+        echo "  -h|--help       Show this usage statement."
+        echo "  -n|--no-update  Don't update before building; just build."
+        echo "  -d|--docker     Use Docker to build in and serve from a container."
+        echo "  -q|--quiet      Don't emit any messages except errors/warnings."
+        echo "  -v|--verbose    Show verbose output from every build step."
+        exit 0
+        ;;
+      -n|--no-update|--no-updates)
+        DO_UPDATE=false
+        ;;
+      -d|--docker)
+        USE_DOCKER=true
+        ;;
+      -q|--quiet)
+        QUIET=true
+        VERBOSE=false
+        ;;
+      -v|--verbose)
+        VERBOSE=true
+        QUIET=false
+        set -vx
+        ;;
+      *)
+        ;;
+    esac
+  done
 
-# $SKIP_BUILD_UPDATE_CHECK is set inside the Dockerfile so that we don't check for updates both inside and outside
-# the Docker container.
-if [[ "$DO_UPDATE" == true && "$SKIP_BUILD_UPDATE_CHECK" != true ]]; then
-  $QUIET || echo "Checking if html-build is up to date..."
-  GIT_FETCH_ARGS=()
-  if ! $VERBOSE ; then
-    GIT_FETCH_ARGS+=( --quiet )
+  # $SKIP_BUILD_UPDATE_CHECK is set inside the Dockerfile so that we don't check for updates both inside and outside
+  # the Docker container.
+  if [[ "$DO_UPDATE" == true && "$SKIP_BUILD_UPDATE_CHECK" != true ]]; then
+    $QUIET || echo "Checking if html-build is up to date..."
+    GIT_FETCH_ARGS=()
+    if ! $VERBOSE ; then
+      GIT_FETCH_ARGS+=( --quiet )
+    fi
+    # TODO: `git remote get-url origin` is nicer, but new in Git 2.7.
+    ORIGIN_URL=$(git config --get remote.origin.url)
+    GIT_FETCH_ARGS+=( "$ORIGIN_URL" master)
+    git fetch "${GIT_FETCH_ARGS[@]}"
+    NEW_COMMITS=$(git rev-list --count HEAD..FETCH_HEAD)
+    if [ "$NEW_COMMITS" != "0" ]; then
+      $QUIET || echo
+      echo -n "Your local branch is $NEW_COMMITS "
+      [ "$NEW_COMMITS" == "1" ] && echo -n commit || echo -n commits
+      echo " behind $ORIGIN_URL:"
+      git log --oneline HEAD..FETCH_HEAD
+      echo
+      echo "To update, run this command:"
+      echo
+      echo "  git pull --rebase origin master"
+      echo
+      echo "This check can be bypassed with the --no-update option."
+      exit 1
+    fi
   fi
-  # TODO: `git remote get-url origin` is nicer, but new in Git 2.7.
-  ORIGIN_URL=$(git config --get remote.origin.url)
-  GIT_FETCH_ARGS+=( "$ORIGIN_URL" master)
-  git fetch "${GIT_FETCH_ARGS[@]}"
-  NEW_COMMITS=$(git rev-list --count HEAD..FETCH_HEAD)
-  if [ "$NEW_COMMITS" != "0" ]; then
-    $QUIET || echo
-    echo -n "Your local branch is $NEW_COMMITS "
-    [ "$NEW_COMMITS" == "1" ] && echo -n commit || echo -n commits
-    echo " behind $ORIGIN_URL:"
-    git log --oneline HEAD..FETCH_HEAD
+
+  $QUIET || echo "Looking for the HTML source (set HTML_SOURCE to override)..."
+  if [ -z "$HTML_SOURCE" ]; then
+    PARENT_DIR=$(dirname "$DIR")
+    if [ -f "$PARENT_DIR/html/source" ]; then
+      HTML_SOURCE=$PARENT_DIR/html
+      $QUIET || echo "Found $HTML_SOURCE (alongside html-build)..."
+    else
+      if [ -f "$DIR/html/source" ]; then
+        HTML_SOURCE=$DIR/html
+        $QUIET || echo "Found $HTML_SOURCE (inside html-build)..."
+      else
+        $QUIET || echo "Didn't find the HTML source on your system..."
+        chooseRepo
+      fi
+    fi
+  else
+    if [ -f "$HTML_SOURCE/source" ]; then
+      $QUIET || echo "Found $HTML_SOURCE (from HTML_SOURCE)..."
+    else
+      $QUIET || echo "Looked in the $HTML_SOURCE directory but didn't find HTML source there..."
+      unset HTML_SOURCE
+      chooseRepo
+    fi
+  fi
+  export HTML_SOURCE
+
+  HTML_GIT_DIR="$HTML_SOURCE/.git/"
+  HTML_SHA=${SHA_OVERRIDE:-$(git --git-dir="$HTML_GIT_DIR" rev-parse HEAD)}
+
+  if [ "$USE_DOCKER" == true ]; then
+    if [[ "$HTML_SOURCE" != $(pwd)/* ]]; then
+      echo "When using Docker, the HTML source must be checked out in a subdirectory of the html-build repo. Cannot continue."
+      exit 1
+    fi
+
+    # $SOURCE_RELATIVE helps on Windows with Git Bash, where /c/... is a symlink, which Docker doesn't like.
+    SOURCE_RELATIVE=$(relativePath "$(pwd)" "$HTML_SOURCE")
+
+    VERBOSE_OR_QUIET_FLAG=""
+    $QUIET && VERBOSE_OR_QUIET_FLAG+="--quiet"
+    $VERBOSE && VERBOSE_OR_QUIET_FLAG+="--verbose"
+
+    NO_UPDATE_FLAG="--no-update"
+    $DO_UPDATE && NO_UPDATE_FLAG=""
+
+    DOCKER_ARGS=( --tag whatwg-html \
+                  --build-arg "html_source_dir=$SOURCE_RELATIVE" \
+                  --build-arg "verbose_or_quiet_flag=$VERBOSE_OR_QUIET_FLAG" \
+                  --build-arg "no_update_flag=$NO_UPDATE_FLAG" \
+                  --build-arg "sha_override=$HTML_SHA" )
+    if $QUIET; then
+      DOCKER_ARGS+=( --quiet )
+    fi
+
+    docker build "${DOCKER_ARGS[@]}" .
+    echo "Running server on http://localhost:8080"
+    docker run --rm -it -p 8080:80 whatwg-html
+    exit 0
+  fi
+
+
+  $QUIET || echo "Linting the source file..."
+  ./lint.sh "$HTML_SOURCE/source" || {
     echo
-    echo "To update, run this command:"
-    echo
-    echo "  git pull --rebase origin master"
-    echo
-    echo "This check can be bypassed with the --no-update option."
+    echo "There were lint errors. Stopping."
     exit 1
+  }
+
+  if [ -d "$HTML_CACHE" ]; then
+    PREV_BUILD_SHA=$( cat "$HTML_CACHE/last-build-sha.txt" 2>/dev/null || echo )
+    CURRENT_BUILD_SHA=$( git rev-parse HEAD )
+
+    if [ "$PREV_BUILD_SHA" != "$CURRENT_BUILD_SHA" ]; then
+      $QUIET || echo "Build tools have been updated since last run; clearing the cache..."
+      DO_UPDATE=true
+      rm -rf "$HTML_CACHE"
+      mkdir -p "$HTML_CACHE"
+      echo "$CURRENT_BUILD_SHA" > "$HTML_CACHE/last-build-sha.txt"
+    fi
+  else
+    mkdir -p "$HTML_CACHE"
   fi
-fi
+
+  CURL_ARGS=()
+  if ! $VERBOSE; then
+    CURL_ARGS+=( --silent )
+  fi
+
+  CURL_CANIUSE_ARGS=( "${CURL_ARGS[@]}" --output "$HTML_CACHE/caniuse.json" -k )
+  CURL_W3CBUGS_ARGS=( "${CURL_ARGS[@]}" --output "$HTML_CACHE/w3cbugs.csv" )
+
+  if [[ "$DO_UPDATE" == true || ! -f "$HTML_CACHE/caniuse.json" ]]; then
+    rm -f "$HTML_CACHE/caniuse.json"
+    $QUIET || echo "Downloading caniuse data..."
+    curl "${CURL_CANIUSE_ARGS[@]}" \
+      https://raw.githubusercontent.com/Fyrd/caniuse/master/data.json
+  fi
+
+  if [[ "$DO_UPDATE" == true || ! -f "$HTML_CACHE/w3cbugs.csv" ]]; then
+    rm -f "$HTML_CACHE/w3cbugs.csv"
+    $QUIET || echo "Downloading list of W3C bugzilla bugs..."
+    curl "${CURL_W3CBUGS_ARGS[@]}" \
+      'https://www.w3.org/Bugs/Public/buglist.cgi?columnlist=bug_file_loc,short_desc&query_format=advanced&resolution=---&ctype=csv&status_whiteboard=whatwg-resolved&status_whiteboard_type=notregexp&bug_file_loc=http&bug_file_loc_type=substring&product=WHATWG&product=HTML%20WG&product=CSS&product=WebAppsWG'
+  fi
+
+  rm -rf "$HTML_OUTPUT" && mkdir -p "$HTML_OUTPUT"
+  # Set these up so rsync will not complain about either being missing
+  mkdir -p "$HTML_OUTPUT/commit-snapshots"
+  mkdir -p "$HTML_OUTPUT/review-drafts"
+
+  processSource "source" "default"
+
+  if [[ -e "$HTML_GIT_DIR" ]]; then
+    # This is based on https://github.com/whatwg/whatwg.org/pull/201 and should be kept synchronized
+    # with that.
+    CHANGED_FILES=$(git --git-dir="$HTML_GIT_DIR" diff --name-only HEAD^ HEAD)
+    for CHANGED in $CHANGED_FILES; do # Omit quotes around variable to split on whitespace
+      if ! [[ "$CHANGED" =~ ^review-drafts/.*.wattsi$ ]]; then
+        continue
+      fi
+      processSource "$CHANGED" "review"
+    done
+  else
+    echo ""
+    echo "Skipping review draft production as the .git directory is not present"
+    echo "(This always happens if you use the --docker option.)"
+  fi
+
+  $QUIET || echo
+  $QUIET || echo "Success!"
+}
 
 function chooseRepo {
   echo
@@ -196,35 +329,6 @@ function confirmRepo {
   fi
 }
 
-$QUIET || echo "Looking for the HTML source (set HTML_SOURCE to override)..."
-if [ -z "$HTML_SOURCE" ]; then
-  PARENT_DIR=$(dirname "$DIR")
-  if [ -f "$PARENT_DIR/html/source" ]; then
-    HTML_SOURCE=$PARENT_DIR/html
-    $QUIET || echo "Found $HTML_SOURCE (alongside html-build)..."
-  else
-    if [ -f "$DIR/html/source" ]; then
-      HTML_SOURCE=$DIR/html
-      $QUIET || echo "Found $HTML_SOURCE (inside html-build)..."
-    else
-      $QUIET || echo "Didn't find the HTML source on your system..."
-      chooseRepo
-    fi
-  fi
-else
-  if [ -f "$HTML_SOURCE/source" ]; then
-    $QUIET || echo "Found $HTML_SOURCE (from HTML_SOURCE)..."
-  else
-    $QUIET || echo "Looked in the $HTML_SOURCE directory but didn't find HTML source there..."
-    unset HTML_SOURCE
-    chooseRepo
-  fi
-fi
-export HTML_SOURCE
-
-HTML_GIT_DIR="$HTML_SOURCE/.git/"
-HTML_SHA=${SHA_OVERRIDE:-$(git --git-dir="$HTML_GIT_DIR" rev-parse HEAD)}
-
 # From http://stackoverflow.com/a/12498485
 function relativePath {
   # both $1 and $2 are absolute paths beginning with /
@@ -267,87 +371,6 @@ function relativePath {
   echo "$result"
 }
 
-if [ "$USE_DOCKER" == true ]; then
-  if [[ "$HTML_SOURCE" != $(pwd)/* ]]; then
-    echo "When using Docker, the HTML source must be checked out in a subdirectory of the html-build repo. Cannot continue."
-    exit 1
-  fi
-
-  # $SOURCE_RELATIVE helps on Windows with Git Bash, where /c/... is a symlink, which Docker doesn't like.
-  SOURCE_RELATIVE=$(relativePath "$(pwd)" "$HTML_SOURCE")
-
-  VERBOSE_OR_QUIET_FLAG=""
-  $QUIET && VERBOSE_OR_QUIET_FLAG+="--quiet"
-  $VERBOSE && VERBOSE_OR_QUIET_FLAG+="--verbose"
-
-  NO_UPDATE_FLAG="--no-update"
-  $DO_UPDATE && NO_UPDATE_FLAG=""
-
-  DOCKER_ARGS=( --tag whatwg-html \
-                --build-arg "html_source_dir=$SOURCE_RELATIVE" \
-                --build-arg "verbose_or_quiet_flag=$VERBOSE_OR_QUIET_FLAG" \
-                --build-arg "no_update_flag=$NO_UPDATE_FLAG" \
-                --build-arg "sha_override=$HTML_SHA" )
-  if $QUIET; then
-    DOCKER_ARGS+=( --quiet )
-  fi
-
-  docker build "${DOCKER_ARGS[@]}" .
-  echo "Running server on http://localhost:8080"
-  docker run --rm -it -p 8080:80 whatwg-html
-  exit 0
-fi
-
-
-$QUIET || echo "Linting the source file..."
-./lint.sh "$HTML_SOURCE/source" || {
-  echo
-  echo "There were lint errors. Stopping."
-  exit 1
-}
-
-if [ -d "$HTML_CACHE" ]; then
-  PREV_BUILD_SHA=$( cat "$HTML_CACHE/last-build-sha.txt" 2>/dev/null || echo )
-  CURRENT_BUILD_SHA=$( git rev-parse HEAD )
-
-  if [ "$PREV_BUILD_SHA" != "$CURRENT_BUILD_SHA" ]; then
-    $QUIET || echo "Build tools have been updated since last run; clearing the cache..."
-    DO_UPDATE=true
-    rm -rf "$HTML_CACHE"
-    mkdir -p "$HTML_CACHE"
-    echo "$CURRENT_BUILD_SHA" > "$HTML_CACHE/last-build-sha.txt"
-  fi
-else
-  mkdir -p "$HTML_CACHE"
-fi
-
-CURL_ARGS=()
-if ! $VERBOSE; then
-  CURL_ARGS+=( --silent )
-fi
-
-CURL_CANIUSE_ARGS=( "${CURL_ARGS[@]}" --output "$HTML_CACHE/caniuse.json" -k )
-CURL_W3CBUGS_ARGS=( "${CURL_ARGS[@]}" --output "$HTML_CACHE/w3cbugs.csv" )
-
-if [[ "$DO_UPDATE" == true || ! -f "$HTML_CACHE/caniuse.json" ]]; then
-  rm -f "$HTML_CACHE/caniuse.json"
-  $QUIET || echo "Downloading caniuse data..."
-  curl "${CURL_CANIUSE_ARGS[@]}" \
-    https://raw.githubusercontent.com/Fyrd/caniuse/master/data.json
-fi
-
-if [[ "$DO_UPDATE" == true || ! -f "$HTML_CACHE/w3cbugs.csv" ]]; then
-  rm -f "$HTML_CACHE/w3cbugs.csv"
-  $QUIET || echo "Downloading list of W3C bugzilla bugs..."
-  curl "${CURL_W3CBUGS_ARGS[@]}" \
-    'https://www.w3.org/Bugs/Public/buglist.cgi?columnlist=bug_file_loc,short_desc&query_format=advanced&resolution=---&ctype=csv&status_whiteboard=whatwg-resolved&status_whiteboard_type=notregexp&bug_file_loc=http&bug_file_loc_type=substring&product=WHATWG&product=HTML%20WG&product=CSS&product=WebAppsWG'
-fi
-
-rm -rf "$HTML_OUTPUT" && mkdir -p "$HTML_OUTPUT"
-# Set these up so rsync will not complain about either being missing
-mkdir -p "$HTML_OUTPUT/commit-snapshots"
-mkdir -p "$HTML_OUTPUT/review-drafts"
-
 function processSource {
   rm -rf "$HTML_TEMP" && mkdir -p "$HTML_TEMP"
 
@@ -364,75 +387,6 @@ function processSource {
   fi
   perl .pre-process-annotate-attributes.pl < "$HTML_TEMP/source-expanded-1" > "$HTML_TEMP/source-expanded-2" # this one could be merged
   perl .pre-process-tag-omission.pl < "$HTML_TEMP/source-expanded-2" | perl .pre-process-index-generator.pl > "$HTML_TEMP/source-whatwg-complete" # this one could be merged
-
-  function runWattsi {
-    # Input arguments: $1 is the file to run wattsi on, $2 is a directory for wattsi to write output
-    # to
-    # Output:
-    # - Sets global variable $WATTSI_RESULT to an exit code (or equivalent, for HTTP version)
-    # - $HTML_TEMP/wattsi-output directory will contain the output from wattsi on success
-    # - $HTML_TEMP/wattsi-output.txt will contain the output from wattsi, on both success and failure
-
-    rm -rf "$2"
-    mkdir "$2"
-
-    WATTSI_ARGS=()
-    if $QUIET; then
-      WATTSI_ARGS+=( --quiet )
-    fi
-    WATTSI_ARGS+=( "$1" "$HTML_SHA" "$2" "$BUILD_TYPE" "$HTML_CACHE/caniuse.json" "$HTML_CACHE/w3cbugs.csv")
-    if hash wattsi 2>/dev/null; then
-      if [ "$(wattsi --version | cut -d' ' -f2)" -lt "$WATTSI_LATEST" ]; then
-        echo
-        echo "Warning: Your wattsi version is out of date. You should to rebuild an"
-        echo "up-to-date wattsi binary from the wattsi sources."
-        echo
-      fi
-      LOCAL_WATTSI=true
-      WATTSI_RESULT="0"
-      wattsi "${WATTSI_ARGS[@]}" || WATTSI_RESULT=$?
-    else
-      $QUIET || echo
-      $QUIET || echo "Local wattsi is not present; trying the build server..."
-
-      CURL_ARGS=( https://build.whatwg.org/wattsi \
-                  --form "source=@$1" \
-                  --form "sha=$HTML_SHA" \
-                  --form "build=$BUILD_TYPE" \
-                  --form "caniuse=@$HTML_CACHE/caniuse.json" \
-                  --form "w3cbugs=@$HTML_CACHE/w3cbugs.csv" \
-                  --dump-header "$HTML_TEMP/wattsi-headers.txt" \
-                  --output "$HTML_TEMP/wattsi-output.zip" )
-      if $VERBOSE; then
-        CURL_ARGS+=( --verbose )
-      elif $QUIET; then
-        CURL_ARGS+=( --silent )
-      fi
-      curl "${CURL_ARGS[@]}"
-
-      # read exit code from the Wattsi-Exit-Code header and assume failure if not found
-      WATTSI_RESULT=1
-      while IFS=":" read -r NAME VALUE; do
-        if [ "$NAME" == "Wattsi-Exit-Code" ]; then
-          WATTSI_RESULT=$(echo "$VALUE" | tr -d ' \r\n')
-          break
-        fi
-      done < "$HTML_TEMP/wattsi-headers.txt"
-
-      if [ "$WATTSI_RESULT" != "0" ]; then
-        mv "$HTML_TEMP/wattsi-output.zip" "$HTML_TEMP/wattsi-output.txt"
-      else
-        UNZIP_ARGS=()
-        # Note: Don't use the -v flag; it doesn't work in combination with -d
-        if ! $VERBOSE; then
-          UNZIP_ARGS+=( -qq )
-        fi
-        UNZIP_ARGS+=( "$HTML_TEMP/wattsi-output.zip" -d "$2" )
-        unzip "${UNZIP_ARGS[@]}"
-        mv "$2/output.txt" "$HTML_TEMP/wattsi-output.txt"
-      fi
-    fi
-  }
 
   runWattsi "$HTML_TEMP/source-whatwg-complete" "$HTML_TEMP/wattsi-output"
   if [[ "$WATTSI_RESULT" == "0" ]]; then
@@ -456,10 +410,6 @@ function processSource {
     echo "There were errors. Stopping."
     exit "$WATTSI_RESULT"
   fi
-
-  function generateBacklinks {
-    perl .post-process-partial-backlink-generator.pl "$HTML_TEMP/wattsi-output/index-$1" > "$2/index.html";
-  }
 
   if [[ "$BUILD_TYPE" == "default" ]]; then
     # Singlepage HTML
@@ -498,23 +448,77 @@ Disallow: /review-drafts/" > "$HTML_OUTPUT/robots.txt"
   fi
 }
 
-processSource "source" "default"
+function runWattsi {
+  # Input arguments: $1 is the file to run wattsi on, $2 is a directory for wattsi to write output
+  # to
+  # Output:
+  # - Sets global variable $WATTSI_RESULT to an exit code (or equivalent, for HTTP version)
+  # - $HTML_TEMP/wattsi-output directory will contain the output from wattsi on success
+  # - $HTML_TEMP/wattsi-output.txt will contain the output from wattsi, on both success and failure
 
-if [[ -e "$HTML_GIT_DIR" ]]; then
-  # This is based on https://github.com/whatwg/whatwg.org/pull/201 and should be kept synchronized
-  # with that.
-  CHANGED_FILES=$(git --git-dir="$HTML_GIT_DIR" diff --name-only HEAD^ HEAD)
-  for CHANGED in $CHANGED_FILES; do # Omit quotes around variable to split on whitespace
-    if ! [[ "$CHANGED" =~ ^review-drafts/.*.wattsi$ ]]; then
-      continue
+  rm -rf "$2"
+  mkdir "$2"
+
+  WATTSI_ARGS=()
+  if $QUIET; then
+    WATTSI_ARGS+=( --quiet )
+  fi
+  WATTSI_ARGS+=( "$1" "$HTML_SHA" "$2" "$BUILD_TYPE" "$HTML_CACHE/caniuse.json" "$HTML_CACHE/w3cbugs.csv")
+  if hash wattsi 2>/dev/null; then
+    if [ "$(wattsi --version | cut -d' ' -f2)" -lt "$WATTSI_LATEST" ]; then
+      echo
+      echo "Warning: Your wattsi version is out of date. You should to rebuild an"
+      echo "up-to-date wattsi binary from the wattsi sources."
+      echo
     fi
-    processSource "$CHANGED" "review"
-  done
-else
-  echo ""
-  echo "Skipping review draft production as the .git directory is not present"
-  echo "(This always happens if you use the --docker option.)"
-fi
+    LOCAL_WATTSI=true
+    WATTSI_RESULT="0"
+    wattsi "${WATTSI_ARGS[@]}" || WATTSI_RESULT=$?
+  else
+    $QUIET || echo
+    $QUIET || echo "Local wattsi is not present; trying the build server..."
 
-$QUIET || echo
-$QUIET || echo "Success!"
+    CURL_ARGS=( https://build.whatwg.org/wattsi \
+                --form "source=@$1" \
+                --form "sha=$HTML_SHA" \
+                --form "build=$BUILD_TYPE" \
+                --form "caniuse=@$HTML_CACHE/caniuse.json" \
+                --form "w3cbugs=@$HTML_CACHE/w3cbugs.csv" \
+                --dump-header "$HTML_TEMP/wattsi-headers.txt" \
+                --output "$HTML_TEMP/wattsi-output.zip" )
+    if $VERBOSE; then
+      CURL_ARGS+=( --verbose )
+    elif $QUIET; then
+      CURL_ARGS+=( --silent )
+    fi
+    curl "${CURL_ARGS[@]}"
+
+    # read exit code from the Wattsi-Exit-Code header and assume failure if not found
+    WATTSI_RESULT=1
+    while IFS=":" read -r NAME VALUE; do
+      if [ "$NAME" == "Wattsi-Exit-Code" ]; then
+        WATTSI_RESULT=$(echo "$VALUE" | tr -d ' \r\n')
+        break
+      fi
+    done < "$HTML_TEMP/wattsi-headers.txt"
+
+    if [ "$WATTSI_RESULT" != "0" ]; then
+      mv "$HTML_TEMP/wattsi-output.zip" "$HTML_TEMP/wattsi-output.txt"
+    else
+      UNZIP_ARGS=()
+      # Note: Don't use the -v flag; it doesn't work in combination with -d
+      if ! $VERBOSE; then
+        UNZIP_ARGS+=( -qq )
+      fi
+      UNZIP_ARGS+=( "$HTML_TEMP/wattsi-output.zip" -d "$2" )
+      unzip "${UNZIP_ARGS[@]}"
+      mv "$2/output.txt" "$HTML_TEMP/wattsi-output.txt"
+    fi
+  fi
+}
+
+function generateBacklinks {
+  perl .post-process-partial-backlink-generator.pl "$HTML_TEMP/wattsi-output/index-$1" > "$2/index.html";
+}
+
+main "$@"

--- a/ci-deploy/outside-container.sh
+++ b/ci-deploy/outside-container.sh
@@ -30,7 +30,7 @@ docker build --cache-from "$DOCKER_HUB_REPO:latest" \
              --tag "$DOCKER_HUB_REPO:latest" \
              --build-arg "travis_pull_request=$TRAVIS_PULL_REQUEST" \
              .
-if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
+if [[ $TRAVIS_PULL_REQUEST == "false" ]]; then
   # Decrypt the deploy key from this script's location into the html/ directory, since that's the
   # directory that will be shared with the container (but not built into the image).
   ENCRYPTED_KEY_VAR="encrypted_${ENCRYPTION_LABEL}_key"
@@ -45,7 +45,7 @@ fi
 echo ""
 docker run --volume "$(pwd)/html":/whatwg/html "$DOCKER_HUB_REPO:latest"
 
-if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
+if [[ $TRAVIS_PULL_REQUEST == "false" ]]; then
   # If the build succeeded and we got here, upload the Docker image to Docker Hub, so that future runs
   # can use it as a cache.
   echo ""


### PR DESCRIPTION
I got carried away prettying up build.sh. This may not have been the best use of my time. But, it's done now.

I tried to keep each commit atomic. High-level summary:

* Changed clean and help from `./build.sh --clean` to `./build.sh clean` and similar, to indicate that they are commands, not options that modify the default build command.
* Updated the required version of Wattsi.
* Refactored to use a main() function, to make the main execution flow clearer. Then factored out chunks of logic within the main function into their own functions, so that main() became mostly high-level, and you can basically follow how the build process works by reading its ~60 lines
* General bash style consistification

Reviewing this is not urgent. The only thing our users might appreciate is the updated Wattsi version requirement.