### PR TITLE
Add fp-units-fcl dependency for building wattsi

### DIFF
--- a/ci-deploy/Dockerfile
+++ b/ci-deploy/Dockerfile
@@ -3,7 +3,7 @@
 FROM debian:sid
 
 RUN apt-get update && \
-    apt-get install -y ca-certificates curl rsync git unzip fp-compiler default-jre
+    apt-get install -y ca-certificates curl rsync git unzip fp-compiler fp-units-fcl default-jre
 
 ADD wattsi /whatwg/wattsi
 


### PR DESCRIPTION
This change gets the fp-units-fcl package needed for building wattsi now
that the wattsi sources have a dependency on fphttpclient.