### PR TITLE
Add syntax highlighting to all <pre> contents

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "highlighter"]
+	path = highlighter
+	url = git://github.com/tabatkins/highlighter.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:sid
 ## dependency installation: nginx, wattsi, and other build tools
 ## cleanup freepascal since it is no longer needed after wattsi build
 RUN apt-get update && \
-    apt-get install -y ca-certificates curl git unzip fp-compiler fp-units-fcl fp-units-net libc6-dev nginx && \
+    apt-get install -y ca-certificates curl git unzip fp-compiler fp-units-fcl fp-units-net libc6-dev nginx python2.7 python-pip && \
     git clone https://github.com/whatwg/wattsi.git /whatwg/wattsi && \
     cd /whatwg/wattsi && \
     /whatwg/wattsi/build.sh && \

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To build locally, you'll need the following commands installed on your system:
 
 - `curl`, `grep`, `perl`, `unzip`
 
-Optionally, for faster builds, you can install [Wattsi](https://github.com/whatwg/wattsi). If you don't bother with that, the build will use [Wattsi Server](https://github.com/domenic/wattsi-server), which requires an internet connection.
+Optionally, for faster builds, you can install [Wattsi](https://github.com/whatwg/wattsi) and Python 2.7 (necessary for applying syntax highlighting to `pre` contents). If you don't bother with that, the build will use [Wattsi Server](https://github.com/domenic/wattsi-server), which requires an internet connection.
 
 ### Running the build
 

--- a/ci-deploy/Dockerfile
+++ b/ci-deploy/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && \
     fp-compiler fp-units-fcl fp-units-net libc6-dev         \
     default-jre                                             \
     libfontconfig1 libgomp1 libxml2                         \
+    python2.7 python-pip                                    \
     fonts-dejavu fonts-droid-fallback fonts-liberation fonts-symbola fonts-unfonts-core
 
 # Dependency lines above are:
@@ -14,6 +15,7 @@ RUN apt-get update && \
 # - Wattsi
 # - validator
 # - Prince
+# - Highlighter
 # - fonts
 
 # Dependecies of prince_11.3-1_debian8.0_amd64.deb (not used) are libc6 libcurl3 libfontconfig1

--- a/ci-deploy/outside-container.sh
+++ b/ci-deploy/outside-container.sh
@@ -16,6 +16,13 @@ TRAVIS_PULL_REQUEST=${TRAVIS_PULL_REQUEST:-false}
 # - DOCKER_PASSWORD is set from the outside
 # - ENCRYPTION_LABEL is set from the outside
 
+# Initialize the highlighter submodule for html-build
+(
+  cd html-build
+  git submodule init
+  git submodule update
+)
+
 git clone --depth 1 https://github.com/whatwg/wattsi.git wattsi
 
 git clone --depth 1 https://github.com/pts/pdfsizeopt.git pdfsizeopt


### PR DESCRIPTION
This change adds https://github.com/tabatkins/highlighter as a submodule and updates the build script to use the highlight server when running wattsi, as documented at https://github.com/tabatkins/highlighter/issues/6#issuecomment-398550948.

This change reverts the revert made in ffe6f19. It fixes the problem which made that revert necessary; the fix is to make the PYTHONPATH in the local environment include the path to the Pygments copy in the highlighter submodule.

Fixes https://github.com/whatwg/html-build/issues/169

Relies on https://github.com/whatwg/wattsi/pull/63
Addresses https://github.com/whatwg/html-build/issues/113
Relates to https://github.com/whatwg/html/pull/3768 and https://github.com/whatwg/whatwg.org/pull/215