### PR TITLE
Ensure html/demos examples get included correctly

### DIFF
--- a/.pre-process-main.pl
+++ b/.pre-process-main.pl
@@ -44,7 +44,7 @@ while (@lines) {
     if ($line =~ m|^(.*)<!--BOILERPLATE ([-.a-z0-9]+)-->(.*)\n$|os) {
         unshift @lines, split("\n", $1 . `cat $ENV{'HTML_CACHE'}/$2` . $3);
         next;
-    } elsif ($line =~ m!^( *)<pre>EXAMPLE (offline/|workers/|canvas/)((?:[-a-z0-9]+/){1,2}[-a-z0-9]+.[-a-z0-9]+)</pre> *\n$!os) {
+    } elsif ($line =~ m!^( *)<pre[^>]*>(?:<code[^>]*>)?EXAMPLE (offline/|workers/|canvas/)((?:[-a-z0-9]+/){1,2}[-a-z0-9]+.[-a-z0-9]+)(?:</code>)?</pre> *\n$!os) {
         my $indent = $1;
         my $folder = $2;
         my $example = $3;


### PR DESCRIPTION
This changes ensures that the source of the examples from https://github.com/whatwg/html/tree/master/demos get included in the generated spec output as expected.

https://github.com/whatwg/html/commit/a6e5462 changed some markup in a way that regressed behavior so that the examples no longer got included. So this change updates the build to account for the markup change.