### PR TITLE
Make LOCAL_WATTSI false for non-local wattsi case

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -552,10 +552,10 @@ function runWattsi {
       echo "up-to-date wattsi binary from the wattsi sources."
       echo
     fi
-    LOCAL_WATTSI=true
     WATTSI_RESULT="0"
     wattsi "${WATTSI_ARGS[@]}" || WATTSI_RESULT=$?
   else
+    LOCAL_WATTSI=false
     $QUIET || echo
     $QUIET || echo "Local wattsi is not present; trying the build server..."
 


### PR DESCRIPTION
This change causes LOCAL_WATTSI to be explicitly set to false when local wattsi isn’t present. Among other things, that ensures the content of the error log gets emitted to the console as expected. Otherwise no report of the errors is shown. Thanks @mattto

---

We seem to have regressed this in some recent change(s) by changing the build script to initialize LOCAL_WATTSI to true but after that never in any case setting it to false.

I guess the previous behavior is that LOCAL_WATTSI wasn't ever initialized until being set to true in the case where local wattsi was actually present.

Which meant that in the case where local wattsi wasn’t present, we had the build script relying on LOCAL_WATTSI not being true — because we’d never explicitly set it to true (nor to any other value; it was just unset).

So we now need to explicitly set it to false. (Though alternatively, we could initialize it false by default and then set it to true for the local-wattsi case; not sure which way is best...)