### PR TITLE
Ensure the “All Interfaces” index gets generated

### DIFF
--- a/.pre-process-index-generator.pl
+++ b/.pre-process-index-generator.pl
@@ -7,7 +7,7 @@ my $after = '';
 my %definitions;
 my $inpre = 0;
 while (<>) {
-    $inpre = 1 if /<pre class="idl">/os;
+    $inpre = 1 if /<pre><code class="idl"/os;
     if ($inpre && /(partial )?interface <(span|dfn|a href=#[^ >]*)( id="?([^ ">]*)"?)?[^>]*>([^<:]*)?<\/(span|dfn|a)>/os) {
         my $partial = $1;
         my $id;


### PR DESCRIPTION
This change ensures the “All Interfaces” index gets generated as expected (by making the .pre-process-index-generator.pl script looks for `<pre><code class="idl"` markup to find the interface IDL blocks).  Without this change, the index ends up being empty (because the build code was instead looking for `<pre class="idl"`).

The change from `<pre class="idl"` to `<pre><code class="idl"` markup came about as a result of https://github.com/whatwg/html/commit/a6e5462 (“mark up code blocks with their language and `<code>`”).