### PR TITLE
Use HTML checker binary image, not system Java

### DIFF
--- a/ci-deploy/inside-container.sh
+++ b/ci-deploy/inside-container.sh
@@ -27,8 +27,9 @@ IS_TEST_OF_HTML_BUILD_ITSELF=${IS_TEST_OF_HTML_BUILD_ITSELF:-false}
 # Conformance-check the result
 echo ""
 echo "Downloading and running conformance checker..."
-curl --retry 2 --remote-name --fail --location https://github.com/validator/validator/releases/download/jar/vnu.jar
-java -Xmx1g -jar vnu.jar --skip-non-html "$HTML_OUTPUT"
+curl --retry 2 --remote-name --fail --location https://github.com/validator/validator/releases/download/linux/vnu.linux.zip
+unzip vnu.linux.zip
+./vnu-runtime-image/bin/java -Xmx1g -m vnu/nu.validator.client.SimpleCommandLineValidator --skip-non-html "$HTML_OUTPUT"
 echo ""
 
 if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then

--- a/ci-deploy/inside-container.sh
+++ b/ci-deploy/inside-container.sh
@@ -29,6 +29,7 @@ echo ""
 echo "Downloading and running conformance checker..."
 curl --retry 2 --remote-name --fail --location https://github.com/validator/validator/releases/download/linux/vnu.linux.zip
 unzip vnu.linux.zip
+# the -Xmx1g argument sets the size of the Java heap space to 1 gigabyte
 ./vnu-runtime-image/bin/java -Xmx1g -m vnu/nu.validator.client.SimpleCommandLineValidator --skip-non-html "$HTML_OUTPUT"
 echo ""
 


### PR DESCRIPTION
This change makes the HTML-spec deploy build download and use the (Linux) binary image of the HTML checker rather than downloading and using the jar release of the checker and relying on using a system Java runtime to run that jar.

Note that we call ./vnu-runtime-image/bin/java rather than the ./vnu-runtime-image/bin/vnu convenience wrapper script because we need to feed java the -Xmx1g argument.