### PR TITLE
Keep CI without warnings with some manual maintenance

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,9 @@ set -o pipefail
 cd "$(dirname "$0")"
 DIR=$(pwd)
 
-# The latest required version of Wattsi. Update this if you change how ./build.sh invokes Wattsi.
+# The latest required version of Wattsi. Update this and the fallback in
+# https://github.com/whatwg/wattsi/blob/master/src/build.sh if you change how ./build.sh invokes
+# Wattsi.
 WATTSI_LATEST=76
 
 # Shared state variables throughout this script


### PR DESCRIPTION
Helps with https://github.com/whatwg/wattsi/pull/99.