### PR TITLE
Change depth of html/ checkout to 2

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -27,7 +27,7 @@ HTML_SOURCE=${HTML_SOURCE:-}
 HTML_CACHE=${HTML_CACHE:-$DIR/.cache}
 HTML_TEMP=${HTML_TEMP:-$DIR/.temp}
 HTML_OUTPUT=${HTML_OUTPUT:-$DIR/output}
-HTML_GIT_CLONE_OPTIONS=${HTML_GIT_CLONE_OPTIONS:-"--depth=1"}
+HTML_GIT_CLONE_OPTIONS=${HTML_GIT_CLONE_OPTIONS:-"--depth=2"}
 
 # These are used by child scripts, and so we export them
 export HTML_CACHE


### PR DESCRIPTION
Previously we would check-out the html/ sub-repo at depth 1, but later
try and look at HEAD^ - which wouldn't exist. Change to depth=2 to fix
that.