### PR TITLE
Updates to cause build to fail on invalid Web IDL

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ DIR=$(pwd)
 # The latest required version of Wattsi. Update this and the fallback in
 # https://github.com/whatwg/wattsi/blob/master/src/build.sh if you change how ./build.sh invokes
 # Wattsi.
-WATTSI_LATEST=82
+WATTSI_LATEST=83
 
 # Shared state variables throughout this script
 LOCAL_WATTSI=true


### PR DESCRIPTION
This change updates the highlighter submodule and the Wattsi versions:

* the highlighter now respond with 400 if it finds invalid Web IDL
  https://github.com/tabatkins/highlighter/pull/15

* Wattsi now halts if it gets a 400 response from the highlighter
  https://github.com/whatwg/wattsi/pull/103

Fixes https://github.com/whatwg/html-build/issues/201