### PR TITLE
Update to use Docker Hub Wattsi image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,15 +3,11 @@ FROM debian:stable
 ## dependency installation: nginx, wattsi, and other build tools
 ## cleanup freepascal since it is no longer needed after wattsi build
 RUN apt-get update && \
-    apt-get install -y ca-certificates curl git unzip fp-compiler fp-units-fcl fp-units-net libc6-dev nginx python2.7 python-pip && \
-    git clone https://github.com/whatwg/wattsi.git /whatwg/wattsi && \
-    cd /whatwg/wattsi && \
-    /whatwg/wattsi/build.sh && \
-    cp /whatwg/wattsi/bin/wattsi /bin/ && \
-    apt-get purge -y fp-compiler fp-units-fcl fp-units-net && \
-    apt-get autoremove -y && \
+    apt-get install -y ca-certificates curl git unzip nginx python2.7 python-pip && \
     rm -rf /etc/nginx/sites-enabled/* && \
     rm -rf /var/lib/apt/lists/*
+
+COPY --from=whatwg/wattsi:latest /whatwg/wattsi/bin/wattsi /bin/wattsi
 
 ADD . /whatwg/build
 

--- a/ci-deploy/Dockerfile
+++ b/ci-deploy/Dockerfile
@@ -4,7 +4,6 @@ FROM debian:stable
 
 RUN apt-get update && \
     apt-get install -y ca-certificates curl rsync git unzip \
-    fp-compiler fp-units-fcl fp-units-net libc6-dev         \
     default-jre                                             \
     libfontconfig1 libgomp1 libxml2                         \
     python2.7 python-pip                                    \
@@ -12,7 +11,6 @@ RUN apt-get update && \
 
 # Dependency lines above are:
 # - General
-# - Wattsi
 # - validator
 # - Prince
 # - Highlighter
@@ -39,11 +37,7 @@ RUN cd /whatwg && \
     rm -rf pdfsizeopt_libexec.tar.gz pdfsizeopt_libexec
 ENV PATH="/whatwg/pdfsizeopt/bin:${PATH}"
 
-ADD wattsi /whatwg/wattsi
-
-RUN cd /whatwg/wattsi && \
-    /whatwg/wattsi/build.sh
-ENV PATH="/whatwg/wattsi/bin:${PATH}"
+COPY --from=whatwg/wattsi:latest /whatwg/wattsi/bin/wattsi /bin/wattsi
 
 ADD html-build /whatwg/html-build
 

--- a/ci-deploy/outside-container.sh
+++ b/ci-deploy/outside-container.sh
@@ -24,8 +24,6 @@ IS_TEST_OF_HTML_BUILD_ITSELF=${IS_TEST_OF_HTML_BUILD_ITSELF:-false}
   git submodule update
 )
 
-git clone --depth 1 https://github.com/whatwg/wattsi.git wattsi
-
 git clone --depth 1 https://github.com/pts/pdfsizeopt.git pdfsizeopt
 
 # Copy the Docker-related stuff into the working (grandparent) directory.


### PR DESCRIPTION
Follows https://github.com/whatwg/wattsi/pull/118.

---

There is a lot more we could do to make the build process better, using my newfound knowledge of Docker. But I'd like to delay that until we land #227 in some form. This should get the build back up and running for now.