### PR TITLE
Minor tweaks to reduce the Docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM whatwg/wattsi:${WATTSI_VERSION} as wattsi-stage
 
 FROM debian:stable-slim
 RUN apt-get update && \
-    apt-get install -y ca-certificates curl git unzip python3 python3-pip && \
+    apt-get install --yes --no-install-recommends ca-certificates curl git python3 python3-pip && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=wattsi-stage /whatwg/wattsi/bin/wattsi /bin/wattsi


### PR DESCRIPTION
* Do not install zip; it is only needed when using wattsi-server

* Do not install recommended packages

This brings the image size down from 263 MiB to 195 MiB.