### PR TITLE
Include the default html source folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,11 @@ Run the `build.sh` script from inside your `html-build` working directory, like 
 
 The first time this runs, it will look up for the HTML source from a `../html` folder, if it exists. Otherwise, it may ask for your input on where to clone the HTML source from, or where on your system to find it if you've already done that. If you're working to submit a pull request to [whatwg/html](https://github.com/whatwg/html), be sure to give it the URL of your fork.
 
-You may also set the environment variable HTML_SOURCE to use a custom location for the HTML source. e.g.: `HTML_SOURCE=~/hacks/dhtml ./build.sh`.
+You may also set the environment variable `$HTML_SOURCE` to use a custom location for the HTML source. For example:
+
+```bash
+HTML_SOURCE=~/hacks/dhtml ./build.sh
+```
 
 ## Building using a Docker container
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Run the `build.sh` script from inside your `html-build` working directory, like 
 ./build.sh
 ```
 
-The first time this runs, it will look up for the HTML source from a `../html` folder - if it exists. Otherwise, it may ask for your input on where to clone the HTML source from, or where on your system to find it if you've already done that. If you're working to submit a pull request to [whatwg/html](https://github.com/whatwg/html), be sure to give it the URL of your fork.
+The first time this runs, it will look up for the HTML source from a `../html` folder, if it exists. Otherwise, it may ask for your input on where to clone the HTML source from, or where on your system to find it if you've already done that. If you're working to submit a pull request to [whatwg/html](https://github.com/whatwg/html), be sure to give it the URL of your fork.
 
 You may also set the environment variable HTML_SOURCE to use a custom location for the HTML source. e.g.: `HTML_SOURCE=~/hacks/dhtml ./build.sh`.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ Run the `build.sh` script from inside your `html-build` working directory, like 
 ./build.sh
 ```
 
-The first time this runs, it will ask for your input on where to clone the HTML source from, or where on your system to find it if you've already done that. If you're working to submit a pull request to [whatwg/html](https://github.com/whatwg/html), be sure to give it the URL of your fork.
+The first time this runs, it will look up for the HTML source from a `../html` folder - if it exists. Otherwise, it may ask for your input on where to clone the HTML source from, or where on your system to find it if you've already done that. If you're working to submit a pull request to [whatwg/html](https://github.com/whatwg/html), be sure to give it the URL of your fork.
+
+You may also set the environment variable HTML_SOURCE to use a custom location for the HTML source. e.g.: `HTML_SOURCE=~/hacks/dhtml ./build.sh`.
 
 ## Building using a Docker container
 


### PR DESCRIPTION
While following the steps here, I've noticed the `./build.sh` - including the docker run - never asked me for the HTML source folder. The script does a very convenient lookup for a `../html` source folder instead.

This commit also adds a quick paragraph explaining how to set a custom location, based on the source code of the build script. This may be convenient to other users.

These are all suggestions to the documentation. I'd be happy to change the text if necessary, just let me know.