### PR TITLE
Make .pre-process-tag-omission.pl handle headings that break across multiple lines

### DIFF
--- a/.pre-process-tag-omission.pl
+++ b/.pre-process-tag-omission.pl
@@ -27,7 +27,8 @@ while (defined($_ = <>)) {
             $mode = 'optionals';
         } elsif ($_ eq "   <dt><dfn>Void elements</dfn></dt>\n") {
             $mode = 'voids';
-        } elsif ($_ =~ m!<code>([^<]+)</code></dfn> elements?</h4>!) {
+        } elsif ($_ =~ m!<code>([^<]+)</code></dfn> elements?</h4>!
+          || $_ =~ m!id="the-[^-]+-element"[^>]*>The <dfn[^>]*><code>([^<]+)</code>!) {
             $current = $1;
             $mode = 'element';
         }
@@ -37,8 +38,6 @@ while (defined($_ = <>)) {
             push(@lines, \$line);
             $insertionPoints{$current} = \$line;
             $mode = 'bored';
-        } elsif ($_ =~ m!</h!) {
-            die 'confused';
         } else {
             # ignore...
         }


### PR DESCRIPTION
This change makes the `.pre-process-tag-omission.pl` script work as expected in the case where a heading for an element section breaks across multiple lines.

Otherwise, without this change, the script fails for a case like this:

```html
<h4 element data-lt="meta" id="the-meta-element">The <dfn id="meta"><code>meta</code></dfn>
element</h4>
```

...that is, a case where the `element</h4>` part isn’t on the same line as the `<code>meta</code></dfn>` part.

That problem causes the script to fail to add the **Tag omission in text/html** subsection to the `meta` element section.

---

Note that the `.pre-process-tag-omission.pl` script reads the spec source line-by-line, so there’s no easy way to just adjust the heading-checking regular expression to deal with headings the break across multiple lines.