### PR TITLE
Remove DockerHub caching of CI builds (for now)

### DIFF
--- a/ci-deploy/outside-container.sh
+++ b/ci-deploy/outside-container.sh
@@ -15,25 +15,22 @@ function main {
   cd "$TMP_DIR"
   trap cleanTemp EXIT
 
-  DOCKER_USERNAME="domenicdenicola"
-  DOCKER_HUB_REPO="whatwg/html-deploy"
+  DOCKER_TAG="whatwg/html-deploy:latest"
 
   # Set from the outside:
   TRAVIS_PULL_REQUEST=${TRAVIS_PULL_REQUEST:-false}
   IS_TEST_OF_HTML_BUILD_ITSELF=${IS_TEST_OF_HTML_BUILD_ITSELF:-false}
 
   # When not running pull request builds:
-  # - DOCKER_PASSWORD is set from the outside
   # - ENCRYPTION_LABEL is set from the outside
 
   # Build the Docker image, using Docker Hub as a cache. (This will be fast if nothing has changed
   # in wattsi or html-build).
-  docker build --cache-from "$DOCKER_HUB_REPO:latest" \
-              --tag "$DOCKER_HUB_REPO:latest" \
-              --build-arg "html_build_dir=$TMP_DIR" \
-              --build-arg "travis_pull_request=$TRAVIS_PULL_REQUEST" \
-              --build-arg "is_test_of_html_build_itself=$IS_TEST_OF_HTML_BUILD_ITSELF" \
-              .
+  docker build --tag "$DOCKER_TAG" \
+               --build-arg "html_build_dir=$TMP_DIR" \
+               --build-arg "travis_pull_request=$TRAVIS_PULL_REQUEST" \
+               --build-arg "is_test_of_html_build_itself=$IS_TEST_OF_HTML_BUILD_ITSELF" \
+               .
   if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$IS_TEST_OF_HTML_BUILD_ITSELF" == "false" ]]; then
     # Decrypt the deploy key from this script's location into the html/ directory, since that's the
     # directory that will be shared with the container (but not built into the image).
@@ -48,16 +45,7 @@ function main {
   # Run the inside-container.sh script, with the html/ directory mounted inside the container.
   echo ""
   cd "$HERE/../.."
-  docker run --mount "type=bind,source=$(pwd)/html,destination=/whatwg/html,readonly=1" "$DOCKER_HUB_REPO:latest"
-
-  if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$IS_TEST_OF_HTML_BUILD_ITSELF" == "false" ]]; then
-    # If the build succeeded and we got here, upload the Docker image to Docker Hub, so that future runs
-    # can use it as a cache.
-    echo ""
-    docker tag "$DOCKER_HUB_REPO:latest" "$DOCKER_HUB_REPO:$TRAVIS_BUILD_NUMBER" &&
-    docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
-    docker push "$DOCKER_HUB_REPO"
-  fi
+  docker run --mount "type=bind,source=$(pwd)/html,destination=/whatwg/html,readonly=1" "$DOCKER_TAG"
 }
 
 function cleanTemp {


### PR DESCRIPTION
We'd like to move this to GitHub actions, which has simpler and less manual options for caching Docker layers. For now, let's remove the caching that we're doing, so that the transition to GitHub actions is simpler. This will make CI builds and deploys of whatwg/html-build and whatwg/html slower, but we'll survive.

---

This is on top of #252.