### PR TITLE
Fix PDF generation by reverting to Prince 11

### DIFF
--- a/ci-build/Dockerfile
+++ b/ci-build/Dockerfile
@@ -5,12 +5,14 @@ FROM debian:stable
 RUN apt-get update && \
     apt-get install --yes --no-install-recommends \
     ca-certificates curl rsync git                \
+    libfontconfig1 libgomp1 libxml2               \
     default-jre                                   \
     python3 python3-pip                           \
     fonts-dejavu fonts-droid-fallback fonts-liberation fonts-symbola fonts-unfonts-core
 
 # Dependency lines above are:
 # - General
+# - Prince
 # - validator
 # - Highlighter
 # - fonts, for when Prince renders to PDF
@@ -31,11 +33,16 @@ RUN chmod a+rwx /bin/pdfsizeopt/pdfsizeopt
 ADD https://github.com/validator/validator/releases/download/jar/vnu.jar /whatwg/
 
 # Trying to copy Prince from its DockerHub container like the others does not work; it has too many
-# shared library dependencies. So we get the .deb file from the source:
-ADD https://www.princexml.com/download/prince_13.5-1_debian10_amd64.deb .
-RUN apt-get install --yes --no-install-recommends ./prince_13.5-1_debian10_amd64.deb && \
-    rm prince_13.5-1_debian10_amd64.deb && \
-    echo '@font-face { font-family: serif; src: local("Symbola") }' >> /usr/lib/prince/style/fonts.css
+# shared library dependencies. Additionally, Prince 12 and 13 have bad interactions with pdfsizeopt
+# (https://github.com/pts/pdfsizeopt/issues/145, https://github.com/whatwg/html-build/issues/255),
+# and Prince 11's .deb file only works with older version of Debian. So, we do it this way (plus the
+# manual dependency installations in the apt-get section above).
+ADD https://www.princexml.com/download/prince-11.3-linux-generic-x86_64.tar.gz /whatwg/prince.tar.gz
+RUN cd /whatwg && \
+    tar xzf prince.tar.gz && \
+    echo /whatwg/prince | /whatwg/prince-11.3-linux-generic-x86_64/install.sh && \
+    echo '@font-face { font-family: serif; src: local("Symbola") }' >> /whatwg/prince/lib/prince/style/fonts.css && \
+    rm -rf /whatwg/prince.tar.gz /whatwg/prince-11.3-linux-generic-x86_64
 
 ADD . /whatwg/html-build
 

--- a/ci-build/inside-container.sh
+++ b/ci-build/inside-container.sh
@@ -25,8 +25,9 @@ echo ""
 echo ""
 echo "Building PDF..."
 PDF_TMP="$(mktemp --suffix=.pdf)"
-prince --verbose --output "$PDF_TMP" "http://0.0.0.0:$PDF_SERVE_PORT/"
+PATH=/whatwg/prince/bin:$PATH prince --verbose --output "$PDF_TMP" "http://0.0.0.0:$PDF_SERVE_PORT/"
 
 echo ""
 echo "Optimizing PDF..."
-PATH=/bin/pdfsizeopt:$PATH pdfsizeopt --v=30 "$PDF_TMP" "$HTML_OUTPUT/print.pdf"
+TMP_DIR=$(mktemp -d)
+PATH=/bin/pdfsizeopt:$PATH pdfsizeopt --v=30 "--tmp-dir=$TMP_DIR" "$PDF_TMP" "$HTML_OUTPUT/print.pdf"


### PR DESCRIPTION
Closes #255.

Additionally, this uses a custom temporary directory for pdfsizeopt, as
I was getting permission errors (likely due to Docker/Windows/WSL
interactions) when testing this locally with the default temporary
directory being the output directory.