### PR TITLE
Fix PDF generation

### DIFF
--- a/ci-build/Dockerfile
+++ b/ci-build/Dockerfile
@@ -5,44 +5,31 @@ FROM debian:stable
 RUN apt-get update && \
     apt-get install --yes --no-install-recommends \
     ca-certificates curl rsync git                \
-    libfontconfig1 libgomp1 libxml2               \
     default-jre                                   \
     python3 python3-pip                           \
     fonts-dejavu fonts-droid-fallback fonts-liberation fonts-symbola fonts-unfonts-core
 
 # Dependency lines above are:
 # - General
-# - Prince
 # - validator
 # - Highlighter
 # - fonts, for when Prince renders to PDF
 
 COPY --from=whatwg/wattsi:latest /whatwg/wattsi/bin/wattsi /bin/wattsi
-COPY --from=ptspts/pdfsizeopt:latest /bin /bin/pdfsizeopt
 RUN pip3 install bs-highlighter
-
-# The DockerHub container for pdfsizeopt has some useful auxiliary binaries it depends on, but the
-# main binary is outdated and needs updating directly from GitHub:
-# TODO: consolidate these two lines when https://github.com/moby/buildkit/pull/1492 gets released
-# (see https://github.com/moby/moby/issues/34819).
-ADD https://github.com/pts/pdfsizeopt/blob/master/pdfsizeopt.single?raw=true /bin/pdfsizeopt/pdfsizeopt
-RUN chmod a+rwx /bin/pdfsizeopt/pdfsizeopt
 
 # The DockerHub container for the validator only contains the server version, so we get the .jar
 # from GitHub:
 ADD https://github.com/validator/validator/releases/download/latest/vnu.jar /whatwg/
 
 # Trying to copy Prince from its DockerHub container like the others does not work; it has too many
-# shared library dependencies. Additionally, Prince 12 and 13 have bad interactions with pdfsizeopt
-# (https://github.com/pts/pdfsizeopt/issues/145, https://github.com/whatwg/html-build/issues/255),
-# and Prince 11's .deb file only works with older version of Debian. So, we do it this way (plus the
-# manual dependency installations in the apt-get section above).
-ADD https://www.princexml.com/download/prince-11.3-linux-generic-x86_64.tar.gz /whatwg/prince.tar.gz
+# shared library dependencies. Probably this is a job for Docker Compose... we should learn how that
+# works one day.
+ADD https://www.princexml.com/download/prince_14.2-1_debian10_amd64.deb /whatwg/prince.deb
 RUN cd /whatwg && \
-    tar xzf prince.tar.gz && \
-    echo /whatwg/prince | /whatwg/prince-11.3-linux-generic-x86_64/install.sh && \
-    echo '@font-face { font-family: serif; src: local("Symbola") }' >> /whatwg/prince/lib/prince/style/fonts.css && \
-    rm -rf /whatwg/prince.tar.gz /whatwg/prince-11.3-linux-generic-x86_64
+    apt-get install --yes ./prince.deb && \
+    echo '@font-face { font-family: serif; src: local("Symbola") }' >> /usr/lib/prince/style/fonts.css && \
+    rm -rf /whatwg/prince.deb
 
 ADD . /whatwg/html-build
 

--- a/ci-build/inside-container.sh
+++ b/ci-build/inside-container.sh
@@ -24,10 +24,4 @@ echo ""
 
 echo ""
 echo "Building PDF..."
-PDF_TMP="$(mktemp --suffix=.pdf)"
-PATH=/whatwg/prince/bin:$PATH prince --verbose --output "$PDF_TMP" "http://0.0.0.0:$PDF_SERVE_PORT/"
-
-echo ""
-echo "Optimizing PDF..."
-TMP_DIR=$(mktemp -d)
-PATH=/bin/pdfsizeopt:$PATH pdfsizeopt --v=30 "--tmp-dir=$TMP_DIR" "$PDF_TMP" "$HTML_OUTPUT/print.pdf"
+PATH=/whatwg/prince/bin:$PATH prince --verbose --output "$HTML_OUTPUT/print.pdf" "http://0.0.0.0:$PDF_SERVE_PORT/"


### PR DESCRIPTION
Subresources were not downloading correctly, likely due to the old version of Prince having out-of-date SSL support. (I noticed it emitting warnings about invalid certificates for resources.whatwg.org.)

This upgrades to the latest version of Prince. Doing so requires abandoning pdfsizeopt, as pdfsizeopt is not compatible with modern Prince. Oh well.

This allows us to use a .deb-based installation procedure for Prince instead of compiling from source, which is nice. In particular we no longer need to manually install dependencies.

<del>Also changes the docker-run.sh script to make it more friendly to interactive use (e.g. when debugging).</del><ins>Nope, supporting both interactive mode and CI mode would require some extra work, so let's just leave this as-is.</ins>