### PR TITLE
Fix relative links in the PDF version

### DIFF
--- a/ci-build/docker-build.sh
+++ b/ci-build/docker-build.sh
@@ -27,7 +27,6 @@ function main {
   # Build the Docker image, using Docker Hub as a cache. (This will be fast if nothing has changed
   # in html-build or its dependencies).
   docker pull whatwg/wattsi
-  docker pull ptspts/pdfsizeopt
   docker pull "$docker_hub_repo" || true
   docker build --cache-from "$docker_hub_repo" --tag "$docker_hub_repo" .
 }


### PR DESCRIPTION
Closes https://github.com/whatwg/html/issues/9097.

Also contains a drive-by fix to remove the step which pulls down pdfsizeopt, which we no longer use after https://github.com/whatwg/html-build/commit/18b6e24846fbdaa9041b6eb841b37ed6b8d2a1e2.