### PR TITLE
Require the latest Wattsi

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ DIR=$(pwd)
 # The latest required version of Wattsi. Update this if you change how ./build.sh invokes Wattsi;
 # it will cause a warning if Wattsi's self-reported version is lower. Note that there's no need to
 # update this on every revision of Wattsi; only do so when a warning is justified.
-WATTSI_LATEST=136
+WATTSI_LATEST=137
 
 # Shared state variables throughout this script
 LOCAL_WATTSI=true


### PR DESCRIPTION
This ensures we pull in the <ref> changes in https://github.com/whatwg/wattsi/pull/152.

---

This should be merged after https://github.com/whatwg/wattsi/pull/152 is merged and we double-check that the Wattsi version is indeed 137.

We may need to force-merge this despite CI depending on how the html pull request goes, due to a circular dependency. We can then re-run CI after everything has settled across all three repos.