### PR TITLE
Avoid generating review drafts for merge commits.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -87,7 +87,7 @@ function main {
   if [[ -e "$HTML_GIT_DIR" ]]; then
     # This is based on https://github.com/whatwg/whatwg.org/pull/201 and should be kept synchronized
     # with that.
-    CHANGED_FILES=$(git --git-dir="$HTML_GIT_DIR" diff --name-only HEAD^ HEAD)
+    CHANGED_FILES=$(git --git-dir="$HTML_GIT_DIR" show --format="format:" --name-only HEAD)
     for CHANGED in $CHANGED_FILES; do # Omit quotes around variable to split on whitespace
       if ! [[ "$CHANGED" =~ ^review-drafts/.*.wattsi$ ]]; then
         continue


### PR DESCRIPTION
This avoids generating review drafts for merge commits unless the merge commit has modifications to the review draft (which I hope means that it's different from *all* parents of the merge).

The code prior to this change tries to generate a review draft if the first parent of the merge commit introduces a review draft.  (This happens if "git merge main" is done on a feature branch and main has introduced a review draft.)

---

This came up in the discussion starting in https://github.com/whatwg/html/pull/9400#issuecomment-1730545420 .

I'm not aware of a better way to tell `git show` to skip the header other than `--format=format:`.

I'm not 100% sure about how this handles all edge cases, but I tested the git command against the basic cases of a regular commit that does or doesn't modify a review draft, and against two variants of merge commit from the above pull (with parents in both orders).