### PR TITLE
Pass --no-pager to git log command.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -229,7 +229,7 @@ function checkHTMLBuildIsUpToDate {
     echo -n "Your local branch is $new_commits "
     [[ $new_commits == "1" ]] && echo -n "commit" || echo -n "commits"
     echo " behind $origin_url:"
-    git log --oneline HEAD..FETCH_HEAD
+    git log --no-pager --oneline HEAD..FETCH_HEAD
     echo
     echo "To update, run this command:"
     echo


### PR DESCRIPTION
Without `--no-pager`, this command can (depending on the user's pager settings) cause `build.sh` to show just a full screen git log in the user's pager (for example, if `PAGER="less -Cemf"`).  This behavior is unexpected, and it seems like the intended behavior here is to have the git log appear as a continuous part of the output.