### PR TITLE
Output parse errors for the Rust part of the build step

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "delegate"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e018fccbeeb50ff26562ece792ed06659b9c2dae79ece77c4456bb10d9bf79b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,6 +122,7 @@ checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 name = "html-build"
 version = "0.0.0"
 dependencies = [
+ "delegate",
  "html5ever",
  "markup5ever_rcdom",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ tokio = { version = "1", features = ["full"] }
 html5ever = "0.26.0"
 markup5ever_rcdom = "0.2.0"
 regex = "1"
+delegate = "0.12.0"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/annotate_attributes.rs
+++ b/src/annotate_attributes.rs
@@ -313,6 +313,7 @@ mod tests {
         // reordered in the HTML spec).
         let document = parse_document_async(
             r#"
+<!DOCTYPE html>
 <h3>The a element</h3>
 <dl class="element">
     <dt>Categories
@@ -338,7 +339,7 @@ mod tests {
         assert_eq!(
             serialize_for_test(&[document]),
             r#"
-<html><head></head><body><h3>The a element</h3>
+<!DOCTYPE html><html><head></head><body><h3>The a element</h3>
 <dl class="element">
     <dt>Categories
     </dt><dd>Flow content
@@ -369,6 +370,7 @@ mod tests {
         // i.e., the variant description is used where requested
         let document = parse_document_async(
             r#"
+<!DOCTYPE html>
 <h3>The a element</h3>
 <dl class="element">
     <dt><span data-x="concept-element-attributes">Content attributes</span>
@@ -390,7 +392,7 @@ mod tests {
         assert_eq!(
             serialize_for_test(&[document]),
             r#"
-<html><head></head><body><h3>The a element</h3>
+<!DOCTYPE html><html><head></head><body><h3>The a element</h3>
 <dl class="element">
     <dt><span data-x="concept-element-attributes">Content attributes</span>
     </dt><dd><code data-x="attr-a-href">href</code>
@@ -415,6 +417,7 @@ mod tests {
         // Checks that the special rules for using : instead of an em dash work.
         let document = parse_document_async(
             r#"
+<!DOCTYPE html>
 <h3>The a element</h3>
 <dl class="element">
     <dt><span data-x="concept-element-attributes">Content attributes</span>
@@ -431,7 +434,7 @@ mod tests {
         assert_eq!(
             serialize_for_test(&[document]),
             r#"
-<html><head></head><body><h3>The a element</h3>
+<!DOCTYPE html><html><head></head><body><h3>The a element</h3>
 <dl class="element">
     <dt><span data-x="concept-element-attributes">Content attributes</span>
     </dt><dd>Also, the <code data-x="attr-a-name">name</code> attribute <span data-x="attr-a-name">has special semantics</span> on this element: Anchor name
@@ -450,6 +453,7 @@ mod tests {
         // Checks that the special rules for joining any special semantics with a ; work.
         let document = parse_document_async(
             r#"
+<!DOCTYPE html>
 <h3>The a element</h3>
 <dl class="element">
     <dt><span data-x="concept-element-attributes">Content attributes</span>
@@ -467,7 +471,7 @@ mod tests {
         assert_eq!(
             serialize_for_test(&[document]),
             r#"
-<html><head></head><body><h3>The a element</h3>
+<!DOCTYPE html><html><head></head><body><h3>The a element</h3>
 <dl class="element">
     <dt><span data-x="concept-element-attributes">Content attributes</span>
     </dt><dd>Also, the <code data-x="attr-a-name">name</code> attribute <span data-x="attr-a-name">has special semantics</span> on this element: Anchor name; Name of the anchor
@@ -488,6 +492,7 @@ mod tests {
         // repeating the description.
         let document = parse_document_async(
             r#"
+<!DOCTYPE html>
 <h3>The img element</h3>
 <dl class="element">
     <dt><span data-x="concept-element-attributes">Content attributes</span>
@@ -509,7 +514,7 @@ mod tests {
         assert_eq!(
             serialize_for_test(&[document]),
             r#"
-<html><head></head><body><h3>The img element</h3>
+<!DOCTYPE html><html><head></head><body><h3>The img element</h3>
 <dl class="element">
     <dt><span data-x="concept-element-attributes">Content attributes</span>
     </dt><dd><code data-x="attr-dim-width">width</code>

--- a/src/boilerplate.rs
+++ b/src/boilerplate.rs
@@ -170,14 +170,16 @@ mod tests {
             "<tr><td>en<td>English",
         )
         .await?;
-        let document =
-            parse_document_async("<table><!--BOILERPLATE languages-->".as_bytes()).await?;
+        let document = parse_document_async(
+            "<!DOCTYPE html><table><!--BOILERPLATE languages--></table>".as_bytes(),
+        )
+        .await?;
         let mut proc = Processor::new(boilerplate_dir.path(), Path::new("."));
         dom_utils::scan_dom(&document, &mut |h| proc.visit(h));
         proc.apply().await?;
         assert_eq!(
             serialize_for_test(&[document]),
-            "<html><head></head><body><table><tbody><tr><td>en</td><td>English</td></tr></tbody></table></body></html>");
+            "<!DOCTYPE html><html><head></head><body><table><tbody><tr><td>en</td><td>English</td></tr></tbody></table></body></html>");
         Ok(())
     }
 
@@ -189,15 +191,16 @@ mod tests {
             "data:text/html,Hello, world!",
         )
         .await?;
-        let document =
-            parse_document_async("<a href=\"<!--BOILERPLATE data.url-->\">hello</a>".as_bytes())
-                .await?;
+        let document = parse_document_async(
+            "<!DOCTYPE html><a href=\"<!--BOILERPLATE data.url-->\">hello</a>".as_bytes(),
+        )
+        .await?;
         let mut proc = Processor::new(boilerplate_dir.path(), Path::new("."));
         dom_utils::scan_dom(&document, &mut |h| proc.visit(h));
         proc.apply().await?;
         assert_eq!(
             serialize_for_test(&[document]),
-            "<html><head></head><body><a href=\"data:text/html,Hello, world!\">hello</a></body></html>");
+            "<!DOCTYPE html><html><head></head><body><a href=\"data:text/html,Hello, world!\">hello</a></body></html>");
         Ok(())
     }
 
@@ -208,23 +211,23 @@ mod tests {
         tokio::fs::write(example_dir.path().join("ex2"), "second").await?;
         tokio::fs::write(example_dir.path().join("ignored"), "bad").await?;
         let document =
-            parse_document_async("<pre>EXAMPLE ex1</pre><pre><code class=html>\nEXAMPLE ex2  </code></pre><p>EXAMPLE ignored</p>".as_bytes())
+            parse_document_async("<!DOCTYPE html><pre>EXAMPLE ex1</pre><pre><code class=html>\nEXAMPLE ex2  </code></pre><p>EXAMPLE ignored</p>".as_bytes())
                 .await?;
         let mut proc = Processor::new(Path::new("."), example_dir.path());
         dom_utils::scan_dom(&document, &mut |h| proc.visit(h));
         proc.apply().await?;
         assert_eq!(
             serialize_for_test(&[document]),
-            "<html><head></head><body><pre>first</pre><pre><code class=\"html\">second</code></pre><p>EXAMPLE ignored</p></body></html>" );
+            "<!DOCTYPE html><html><head></head><body><pre>first</pre><pre><code class=\"html\">second</code></pre><p>EXAMPLE ignored</p></body></html>" );
         Ok(())
     }
 
     #[tokio::test]
     async fn test_errors_unsafe_paths() -> io::Result<()> {
         let bad_path_examples = [
-            "<body><!--BOILERPLATE /etc/passwd-->",
-            "<body><pre data-x=\"<!--BOILERPLATE src/../../foo-->\"></pre>",
-            "<body><pre>EXAMPLE ../foo</pre>",
+            "<!DOCTYPE html><body><!--BOILERPLATE /etc/passwd-->",
+            "<!DOCTYPE html><body><pre data-x=\"<!--BOILERPLATE src/../../foo-->\"></pre>",
+            "<!DOCTYPE html><body><pre>EXAMPLE ../foo</pre>",
         ];
         for example in bad_path_examples {
             let document = parse_document_async(example.as_bytes()).await?;

--- a/src/interface_index.rs
+++ b/src/interface_index.rs
@@ -188,6 +188,7 @@ mod tests {
     async fn test_two_interfaces_in_one_block() -> io::Result<()> {
         let document = parse_document_async(
             r#"
+<!DOCTYPE html>
 <pre><code class=idl>
 interface <dfn interface>HTMLMarqueeElement</dfn> { ... }
 interface <dfn interface>HTMLBlinkElement</dfn> { ... }
@@ -204,7 +205,7 @@ INSERT INTERFACES HERE
         assert_eq!(
             serialize_for_test(&[document]),
             r#"
-<html><head></head><body><pre><code class="idl">
+<!DOCTYPE html><html><head></head><body><pre><code class="idl">
 interface <dfn interface="">HTMLMarqueeElement</dfn> { ... }
 interface <dfn interface="">HTMLBlinkElement</dfn> { ... }
 </code></pre>
@@ -217,6 +218,7 @@ interface <dfn interface="">HTMLBlinkElement</dfn> { ... }
     async fn test_two_interfaces_in_separate_blocks() -> io::Result<()> {
         let document = parse_document_async(
             r#"
+<!DOCTYPE html>
 <pre><code class=idl>
 interface <dfn interface>HTMLMarqueeElement</dfn> { ... }
 </code></pre>
@@ -235,7 +237,7 @@ INSERT INTERFACES HERE
         assert_eq!(
             serialize_for_test(&[document]),
             r#"
-<html><head></head><body><pre><code class="idl">
+<!DOCTYPE html><html><head></head><body><pre><code class="idl">
 interface <dfn interface="">HTMLMarqueeElement</dfn> { ... }
 </code></pre>
 <pre><code class="idl">
@@ -250,6 +252,7 @@ interface <dfn interface="">HTMLBlinkElement</dfn> { ... }
     async fn interface_with_partial() -> io::Result<()> {
         let document = parse_document_async(
             r#"
+<!DOCTYPE html>
 <pre><code class=idl>
 interface <dfn interface>HTMLMarqueeElement</dfn> { ... }
 </code></pre>
@@ -268,7 +271,7 @@ INSERT INTERFACES HERE
         assert_eq!(
             serialize_for_test(&[document]),
             r##"
-<html><head></head><body><pre><code class="idl">
+<!DOCTYPE html><html><head></head><body><pre><code class="idl">
 interface <dfn interface="">HTMLMarqueeElement</dfn> { ... }
 </code></pre>
 <pre><code class="idl">
@@ -283,6 +286,7 @@ partial interface <span id="HTMLMarqueeElement-partial">HTMLMarqueeElement</span
     async fn interface_with_two_partials() -> io::Result<()> {
         let document = parse_document_async(
             r#"
+<!DOCTYPE html>
 <pre><code class=idl>
 interface <dfn interface>HTMLMarqueeElement</dfn> { ... }
 partial interface <span id=HTMLMarqueeElement-partial>HTMLMarqueeElement</span> { ... }
@@ -300,7 +304,7 @@ INSERT INTERFACES HERE
         assert_eq!(
             serialize_for_test(&[document]),
             r##"
-<html><head></head><body><pre><code class="idl">
+<!DOCTYPE html><html><head></head><body><pre><code class="idl">
 interface <dfn interface="">HTMLMarqueeElement</dfn> { ... }
 partial interface <span id="HTMLMarqueeElement-partial">HTMLMarqueeElement</span> { ... }
 partial interface <span id="HTMLMarqueeElement-partial-2">HTMLMarqueeElement</span> { ... }
@@ -314,6 +318,7 @@ partial interface <span id="HTMLMarqueeElement-partial-2">HTMLMarqueeElement</sp
     async fn only_partials() -> io::Result<()> {
         let document = parse_document_async(
             r#"
+<!DOCTYPE html>
 <pre><code class=idl>
 partial interface <span id=HTMLMarqueeElement-partial>HTMLMarqueeElement</span> { ... }
 partial interface <span id=HTMLMarqueeElement-partial-2>HTMLMarqueeElement</span> { ... }
@@ -330,7 +335,7 @@ INSERT INTERFACES HERE
         assert_eq!(
             serialize_for_test(&[document]),
             r##"
-<html><head></head><body><pre><code class="idl">
+<!DOCTYPE html><html><head></head><body><pre><code class="idl">
 partial interface <span id="HTMLMarqueeElement-partial">HTMLMarqueeElement</span> { ... }
 partial interface <span id="HTMLMarqueeElement-partial-2">HTMLMarqueeElement</span> { ... }
 </code></pre>
@@ -343,6 +348,7 @@ partial interface <span id="HTMLMarqueeElement-partial-2">HTMLMarqueeElement</sp
     async fn marker_before() -> io::Result<()> {
         let document = parse_document_async(
             r#"
+<!DOCTYPE html>
 INSERT INTERFACES HERE
 <pre><code class=idl>
 interface <dfn interface>HTMLMarqueeElement</dfn> { ... }
@@ -358,7 +364,7 @@ interface <dfn interface>HTMLMarqueeElement</dfn> { ... }
         assert_eq!(
             serialize_for_test(&[document]),
             r##"
-<html><head></head><body><ul class="brief"><li><code>HTMLMarqueeElement</code></li></ul>
+<!DOCTYPE html><html><head></head><body><ul class="brief"><li><code>HTMLMarqueeElement</code></li></ul>
 <pre><code class="idl">
 interface <dfn interface="">HTMLMarqueeElement</dfn> { ... }
 </code></pre></body></html>
@@ -370,7 +376,7 @@ interface <dfn interface="">HTMLMarqueeElement</dfn> { ... }
 
     #[tokio::test]
     async fn no_marker() -> io::Result<()> {
-        let document = parse_document_async("".as_bytes()).await?;
+        let document = parse_document_async("<!DOCTYPE html>".as_bytes()).await?;
         let mut proc = Processor::new();
         dom_utils::scan_dom(&document, &mut |h| proc.visit(h));
         let result = proc.apply();
@@ -381,7 +387,8 @@ interface <dfn interface="">HTMLMarqueeElement</dfn> { ... }
     #[tokio::test]
     async fn duplicate_marker() -> io::Result<()> {
         let document = parse_document_async(
-            "<div>INSERT INTERFACES HERE</div><div>INSERT INTERFACES HERE</div>".as_bytes(),
+            "<!DOCTYPE html><div>INSERT INTERFACES HERE</div><div>INSERT INTERFACES HERE</div>"
+                .as_bytes(),
         )
         .await?;
         let mut proc = Processor::new();
@@ -395,6 +402,7 @@ interface <dfn interface="">HTMLMarqueeElement</dfn> { ... }
     async fn duplicate_dfn() -> io::Result<()> {
         let document = parse_document_async(
             r#"
+<!DOCTYPE html>
 <pre><code class=idl>
 interface <dfn interface>HTMLMarqueeElement</dfn> { ... }
 interface <dfn interface>HTMLMarqueeElement</dfn> { ... }

--- a/src/interface_index.rs
+++ b/src/interface_index.rs
@@ -363,12 +363,12 @@ interface <dfn interface>HTMLMarqueeElement</dfn> { ... }
         proc.apply()?;
         assert_eq!(
             serialize_for_test(&[document]),
-            r##"
+            r#"
 <!DOCTYPE html><html><head></head><body><ul class="brief"><li><code>HTMLMarqueeElement</code></li></ul>
 <pre><code class="idl">
 interface <dfn interface="">HTMLMarqueeElement</dfn> { ... }
 </code></pre></body></html>
-            "##
+            "#
             .trim()
         );
         Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,15 @@ mod tag_omission;
 
 #[tokio::main]
 async fn main() -> io::Result<()> {
+    // This gives slightly prettier error-printing.
+    if let Err(e) = run().await {
+        eprintln!("{}", e);
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+async fn run() -> io::Result<()> {
     // Since we're using Rc in the DOM implementation, we must ensure that tasks
     // which act on it are confined to this thread.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod dom_utils;
 mod interface_index;
 mod io_utils;
 mod parser;
+mod rcdom_with_line_numbers;
 mod represents;
 mod tag_omission;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -6,13 +6,15 @@ use html5ever::driver::{self, ParseOpts, Parser};
 use html5ever::tendril::{ByteTendril, TendrilSink};
 use html5ever::tokenizer::TokenizerOpts;
 use html5ever::tree_builder::TreeBuilderOpts;
-use markup5ever_rcdom::{Handle, RcDom};
+use markup5ever_rcdom::Handle;
 use tokio::io::{AsyncRead, AsyncReadExt};
 
+use crate::rcdom_with_line_numbers::RcDomWithLineNumbers;
+
 async fn parse_internal_async<R: AsyncRead + Unpin>(
-    parser: Parser<RcDom>,
+    parser: Parser<RcDomWithLineNumbers>,
     mut r: R,
-) -> io::Result<RcDom> {
+) -> io::Result<RcDomWithLineNumbers> {
     let mut tendril_sink = parser.from_utf8();
 
     // This draws on the structure of the sync tendril read_from.
@@ -45,13 +47,16 @@ pub async fn parse_fragment_async<R: AsyncRead + Unpin>(
     context: &Handle,
 ) -> io::Result<Vec<Handle>> {
     let parser = driver::parse_fragment_for_element(
-        RcDom::default(),
+        RcDomWithLineNumbers::default(),
         create_error_opts(),
         context.clone(),
         None,
     );
-    // TODO handle errors here too I guess
-    let document = parse_internal_async(parser, r).await?.document;
+
+    let dom = parse_internal_async(parser, r).await?;
+    dom.create_error_from_parse_errors()?;
+
+    let document = dom.document();
     let mut new_children = document.children.take()[0].children.take();
     for new_child in new_children.iter_mut() {
         new_child.parent.take();
@@ -60,21 +65,11 @@ pub async fn parse_fragment_async<R: AsyncRead + Unpin>(
 }
 
 pub async fn parse_document_async<R: AsyncRead + Unpin>(r: R) -> io::Result<Handle> {
-    let parser = driver::parse_document(RcDom::default(), create_error_opts());
+    let parser = driver::parse_document(RcDomWithLineNumbers::default(), create_error_opts());
     let dom = parse_internal_async(parser, r).await?;
+    dom.create_error_from_parse_errors()?;
 
-    if !dom.errors.is_empty() {
-        for error in dom.errors {
-            eprintln!("{}", error);
-        }
-        return Err(io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        format!(
-                            "Parse errors encountered"
-                        ),
-                    ))
-    }
-    Ok(dom.document)
+    Ok(dom.document().clone())
 }
 
 fn create_error_opts() -> ParseOpts {
@@ -124,13 +119,33 @@ pub(crate) mod tests {
         // we're in. This is important because of the special rules
         // surrounding, e.g., tables. If you change this to use the body as context,
         // no element at all is emitted.
-        let document = parse_document_async("<!DOCTYPE html><table>".as_bytes()).await?;
+        let document = parse_document_async("<!DOCTYPE html><table></table>".as_bytes()).await?;
         let body = document.children.borrow()[1].children.borrow()[1].clone();
         assert!(body.is_html_element(&local_name!("body")));
         let table = body.children.borrow()[0].clone();
         assert!(table.is_html_element(&local_name!("table")));
         let children = parse_fragment_async("<tbody>".as_bytes(), &table).await?;
         assert_eq!(serialize_for_test(&children), "<tbody></tbody>");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_document_parse_errors() -> io::Result<()> {
+        let result =
+            parse_document_async("<!DOCTYPE html>Hello <strong><em>world</strong></em>".as_bytes())
+                .await;
+        assert!(matches!(result, Err(e) if e.kind() == io::ErrorKind::InvalidData));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_fragment_parse_errors() -> io::Result<()> {
+        let document = parse_document_async("<!DOCTYPE html>".as_bytes()).await?;
+        let body = document.children.borrow()[1].children.borrow()[1].clone();
+        assert!(body.is_html_element(&local_name!("body")));
+        let result =
+            parse_fragment_async("Hello <strong><em>world</strong></em>".as_bytes(), &body).await;
+        assert!(matches!(result, Err(e) if e.kind() == io::ErrorKind::InvalidData));
         Ok(())
     }
 }

--- a/src/rcdom_with_line_numbers.rs
+++ b/src/rcdom_with_line_numbers.rs
@@ -30,10 +30,10 @@ impl RcDomWithLineNumbers {
                 .map(|e| e.to_string())
                 .collect::<Vec<String>>()
                 .join("\n");
-            return Err(io::Error::new(
+            Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!("Parse errors encountered:\n\n{}", error_messages),
-            ));
+            ))
         } else {
             Ok(())
         }

--- a/src/rcdom_with_line_numbers.rs
+++ b/src/rcdom_with_line_numbers.rs
@@ -1,0 +1,179 @@
+// This provides a wrapper around RcDom which tracks line numbers in the errors.
+
+use html5ever::interface::TreeSink;
+use html5ever::{
+    tendril::StrTendril,
+    tree_builder::{ElementFlags, NextParserState, NodeOrText, QuirksMode},
+    Attribute, ExpandedName, QualName,
+};
+use markup5ever_rcdom::{Handle, RcDom};
+use std::borrow::Cow;
+use std::io;
+
+pub struct RcDomWithLineNumbers {
+    dom: RcDom,
+    current_line: u64,
+}
+
+impl RcDomWithLineNumbers {
+    // Expose out the document and errors from the inner RcDom
+    pub fn document(&self) -> &Handle {
+        &self.dom.document
+    }
+
+    pub fn create_error_from_parse_errors(&self) -> io::Result<()> {
+        if !self.dom.errors.is_empty() {
+            let error_messages = self
+                .dom
+                .errors
+                .iter()
+                .map(|e| e.to_string())
+                .collect::<Vec<String>>()
+                .join("\n");
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("Parse errors encountered:\n\n{}", error_messages),
+            ));
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl Default for RcDomWithLineNumbers {
+    fn default() -> Self {
+        Self {
+            dom: RcDom::default(),
+            current_line: 1,
+        }
+    }
+}
+
+impl TreeSink for RcDomWithLineNumbers {
+    type Output = RcDomWithLineNumbers;
+    type Handle = <RcDom as TreeSink>::Handle;
+
+    // Override the parse_error method to add line numbers to the error messages.
+    fn parse_error(&mut self, msg: Cow<'static, str>) {
+        let msg_with_line = format!("Line {}: {}", self.current_line, msg);
+        self.dom.parse_error(Cow::Owned(msg_with_line));
+    }
+
+    // Override to track the current line number.
+    fn set_current_line(&mut self, line: u64) {
+        self.current_line = line;
+    }
+
+    // Override to return RcDomWithLineNumbers instead of RcDom.
+    fn finish(self) -> Self::Output {
+        self
+    }
+
+    // Forward all other methods to RcDom.
+
+    fn get_document(&mut self) -> Self::Handle {
+        self.dom.get_document()
+    }
+
+    fn elem_name<'a>(&'a self, target: &'a Self::Handle) -> ExpandedName<'a> {
+        self.dom.elem_name(target)
+    }
+
+    fn create_element(
+        &mut self,
+        name: QualName,
+        attrs: Vec<Attribute>,
+        flags: ElementFlags,
+    ) -> Self::Handle {
+        self.dom.create_element(name, attrs, flags)
+    }
+
+    fn create_comment(&mut self, text: StrTendril) -> Self::Handle {
+        self.dom.create_comment(text)
+    }
+
+    fn create_pi(&mut self, target: StrTendril, data: StrTendril) -> Self::Handle {
+        self.dom.create_pi(target, data)
+    }
+
+    fn append(&mut self, parent: &Self::Handle, child: NodeOrText<Self::Handle>) {
+        self.dom.append(parent, child)
+    }
+
+    fn append_based_on_parent_node(
+        &mut self,
+        element: &Self::Handle,
+        prev_element: &Self::Handle,
+        child: NodeOrText<Self::Handle>,
+    ) {
+        self.dom
+            .append_based_on_parent_node(element, prev_element, child)
+    }
+
+    fn append_doctype_to_document(
+        &mut self,
+        name: StrTendril,
+        public_id: StrTendril,
+        system_id: StrTendril,
+    ) {
+        self.dom
+            .append_doctype_to_document(name, public_id, system_id)
+    }
+
+    fn mark_script_already_started(&mut self, node: &Self::Handle) {
+        self.dom.mark_script_already_started(node)
+    }
+
+    fn pop(&mut self, node: &Self::Handle) {
+        self.dom.pop(node)
+    }
+
+    fn get_template_contents(&mut self, target: &Self::Handle) -> Self::Handle {
+        self.dom.get_template_contents(target)
+    }
+
+    fn same_node(&self, x: &Self::Handle, y: &Self::Handle) -> bool {
+        self.dom.same_node(x, y)
+    }
+
+    fn set_quirks_mode(&mut self, mode: QuirksMode) {
+        self.dom.set_quirks_mode(mode)
+    }
+
+    fn append_before_sibling(
+        &mut self,
+        sibling: &Self::Handle,
+        new_node: NodeOrText<Self::Handle>,
+    ) {
+        self.dom.append_before_sibling(sibling, new_node)
+    }
+
+    fn add_attrs_if_missing(&mut self, target: &Self::Handle, attrs: Vec<Attribute>) {
+        self.dom.add_attrs_if_missing(target, attrs)
+    }
+
+    fn associate_with_form(
+        &mut self,
+        target: &Self::Handle,
+        form: &Self::Handle,
+        nodes: (&Self::Handle, Option<&Self::Handle>),
+    ) {
+        self.dom.associate_with_form(target, form, nodes)
+    }
+
+    fn remove_from_parent(&mut self, target: &Self::Handle) {
+        self.dom.remove_from_parent(target)
+    }
+
+    fn reparent_children(&mut self, node: &Self::Handle, new_parent: &Self::Handle) {
+        self.dom.reparent_children(node, new_parent)
+    }
+
+    fn is_mathml_annotation_xml_integration_point(&self, handle: &Self::Handle) -> bool {
+        self.dom.is_mathml_annotation_xml_integration_point(handle)
+    }
+
+    fn complete_script(&mut self, node: &Self::Handle) -> NextParserState {
+        self.dom.complete_script(node)
+    }
+}

--- a/src/rcdom_with_line_numbers.rs
+++ b/src/rcdom_with_line_numbers.rs
@@ -1,5 +1,6 @@
 // This provides a wrapper around RcDom which tracks line numbers in the errors.
 
+use delegate::delegate;
 use html5ever::interface::TreeSink;
 use html5ever::{
     tendril::StrTendril,
@@ -69,111 +70,72 @@ impl TreeSink for RcDomWithLineNumbers {
         self
     }
 
-    // Forward all other methods to RcDom.
+    // Delegate all other methods to RcDom.
+    delegate! {
+        to self.dom {
+            fn get_document(&mut self) -> Self::Handle;
 
-    fn get_document(&mut self) -> Self::Handle {
-        self.dom.get_document()
-    }
+            fn elem_name<'a>(&'a self, target: &'a Self::Handle) -> ExpandedName<'a>;
 
-    fn elem_name<'a>(&'a self, target: &'a Self::Handle) -> ExpandedName<'a> {
-        self.dom.elem_name(target)
-    }
+            fn create_element(
+                &mut self,
+                name: QualName,
+                attrs: Vec<Attribute>,
+                flags: ElementFlags,
+            ) -> Self::Handle;
 
-    fn create_element(
-        &mut self,
-        name: QualName,
-        attrs: Vec<Attribute>,
-        flags: ElementFlags,
-    ) -> Self::Handle {
-        self.dom.create_element(name, attrs, flags)
-    }
+            fn create_comment(&mut self, text: StrTendril) -> Self::Handle;
 
-    fn create_comment(&mut self, text: StrTendril) -> Self::Handle {
-        self.dom.create_comment(text)
-    }
+            fn create_pi(&mut self, target: StrTendril, data: StrTendril) -> Self::Handle;
 
-    fn create_pi(&mut self, target: StrTendril, data: StrTendril) -> Self::Handle {
-        self.dom.create_pi(target, data)
-    }
+            fn append(&mut self, parent: &Self::Handle, child: NodeOrText<Self::Handle>);
 
-    fn append(&mut self, parent: &Self::Handle, child: NodeOrText<Self::Handle>) {
-        self.dom.append(parent, child)
-    }
+            fn append_based_on_parent_node(
+                &mut self,
+                element: &Self::Handle,
+                prev_element: &Self::Handle,
+                child: NodeOrText<Self::Handle>,
+            );
 
-    fn append_based_on_parent_node(
-        &mut self,
-        element: &Self::Handle,
-        prev_element: &Self::Handle,
-        child: NodeOrText<Self::Handle>,
-    ) {
-        self.dom
-            .append_based_on_parent_node(element, prev_element, child)
-    }
+            fn append_doctype_to_document(
+                &mut self,
+                name: StrTendril,
+                public_id: StrTendril,
+                system_id: StrTendril,
+            );
 
-    fn append_doctype_to_document(
-        &mut self,
-        name: StrTendril,
-        public_id: StrTendril,
-        system_id: StrTendril,
-    ) {
-        self.dom
-            .append_doctype_to_document(name, public_id, system_id)
-    }
+            fn mark_script_already_started(&mut self, node: &Self::Handle);
 
-    fn mark_script_already_started(&mut self, node: &Self::Handle) {
-        self.dom.mark_script_already_started(node)
-    }
+            fn pop(&mut self, node: &Self::Handle);
 
-    fn pop(&mut self, node: &Self::Handle) {
-        self.dom.pop(node)
-    }
+            fn get_template_contents(&mut self, target: &Self::Handle) -> Self::Handle;
 
-    fn get_template_contents(&mut self, target: &Self::Handle) -> Self::Handle {
-        self.dom.get_template_contents(target)
-    }
+            fn same_node(&self, x: &Self::Handle, y: &Self::Handle) -> bool;
 
-    fn same_node(&self, x: &Self::Handle, y: &Self::Handle) -> bool {
-        self.dom.same_node(x, y)
-    }
+            fn set_quirks_mode(&mut self, mode: QuirksMode);
 
-    fn set_quirks_mode(&mut self, mode: QuirksMode) {
-        self.dom.set_quirks_mode(mode)
-    }
+            fn append_before_sibling(
+                &mut self,
+                sibling: &Self::Handle,
+                new_node: NodeOrText<Self::Handle>,
+            );
 
-    fn append_before_sibling(
-        &mut self,
-        sibling: &Self::Handle,
-        new_node: NodeOrText<Self::Handle>,
-    ) {
-        self.dom.append_before_sibling(sibling, new_node)
-    }
+            fn add_attrs_if_missing(&mut self, target: &Self::Handle, attrs: Vec<Attribute>);
 
-    fn add_attrs_if_missing(&mut self, target: &Self::Handle, attrs: Vec<Attribute>) {
-        self.dom.add_attrs_if_missing(target, attrs)
-    }
+            fn associate_with_form(
+                &mut self,
+                target: &Self::Handle,
+                form: &Self::Handle,
+                nodes: (&Self::Handle, Option<&Self::Handle>),
+            );
 
-    fn associate_with_form(
-        &mut self,
-        target: &Self::Handle,
-        form: &Self::Handle,
-        nodes: (&Self::Handle, Option<&Self::Handle>),
-    ) {
-        self.dom.associate_with_form(target, form, nodes)
-    }
+            fn remove_from_parent(&mut self, target: &Self::Handle);
 
-    fn remove_from_parent(&mut self, target: &Self::Handle) {
-        self.dom.remove_from_parent(target)
-    }
+            fn reparent_children(&mut self, node: &Self::Handle, new_parent: &Self::Handle);
 
-    fn reparent_children(&mut self, node: &Self::Handle, new_parent: &Self::Handle) {
-        self.dom.reparent_children(node, new_parent)
-    }
+            fn is_mathml_annotation_xml_integration_point(&self, handle: &Self::Handle) -> bool;
 
-    fn is_mathml_annotation_xml_integration_point(&self, handle: &Self::Handle) -> bool {
-        self.dom.is_mathml_annotation_xml_integration_point(handle)
-    }
-
-    fn complete_script(&mut self, node: &Self::Handle) -> NextParserState {
-        self.dom.complete_script(node)
+            fn complete_script(&mut self, node: &Self::Handle) -> NextParserState;
+        }
     }
 }

--- a/src/represents.rs
+++ b/src/represents.rs
@@ -128,13 +128,13 @@ mod tests {
     #[tokio::test]
     async fn test_represents() -> io::Result<()> {
         // Uses can occur either before or after.
-        let document = parse_document_async("<p><!--REPRESENTS chair--><p>The <code>chair</code> element <span>represents</span> a seat\nat a <code>table</code>.<p><!--REPRESENTS chair-->".as_bytes()).await?;
+        let document = parse_document_async("<!DOCTYPE html><p><!--REPRESENTS chair--><p>The <code>chair</code> element <span>represents</span> a seat\nat a <code>table</code>.<p><!--REPRESENTS chair-->".as_bytes()).await?;
         let mut proc = Processor::new();
         dom_utils::scan_dom(&document, &mut |h| proc.visit(h));
         proc.apply()?;
         assert_eq!(
             serialize_for_test(&[document]),
-            "<html><head></head><body><p>A seat\nat a <code>table</code>.</p><p>The <code>chair</code> element <span>represents</span> a seat\nat a <code>table</code>.</p><p>A seat\nat a <code>table</code>.</p></body></html>"
+            "<!DOCTYPE html><html><head></head><body><p>A seat\nat a <code>table</code>.</p><p>The <code>chair</code> element <span>represents</span> a seat\nat a <code>table</code>.</p><p>A seat\nat a <code>table</code>.</p></body></html>"
         );
         Ok(())
     }
@@ -142,7 +142,7 @@ mod tests {
     #[tokio::test]
     async fn test_represents_undefined() -> io::Result<()> {
         // Uses can occur either before or after.
-        let document = parse_document_async("<p><!--REPRESENTS chain--><p>The <code>chair</code> element <span>represents</span> a seat\nat a <code>table</code>.<p><!--REPRESENTS chair-->".as_bytes()).await?;
+        let document = parse_document_async("<!DOCTYPE html><p><!--REPRESENTS chain--><p>The <code>chair</code> element <span>represents</span> a seat\nat a <code>table</code>.<p><!--REPRESENTS chair-->".as_bytes()).await?;
         let mut proc = Processor::new();
         dom_utils::scan_dom(&document, &mut |h| proc.visit(h));
         let result = proc.apply();

--- a/src/tag_omission.rs
+++ b/src/tag_omission.rs
@@ -206,6 +206,7 @@ mod tests {
     async fn test_simple() -> io::Result<()> {
         let document = parse_document_async(
             r#"
+<!DOCTYPE html>
 <h3>Optional tags</h3>
 <p>A <code>td</code> element does very tdish things and may be very cellular.</p>
 <p>An <code>audio</code> element is quite audible.</p>
@@ -258,7 +259,7 @@ mod tests {
         assert_eq!(
             serialize_for_test(&[document]),
             r#"
-<html><head></head><body><h3>Optional tags</h3>
+<!DOCTYPE html><html><head></head><body><h3>Optional tags</h3>
 <p>A <code>td</code> element does very tdish things and may be very cellular.</p>
 <p>An <code>audio</code> element is quite audible.</p>
 <h3>Another section</h3>


### PR DESCRIPTION
This fixes #290, by outputting the parse errors encountered by the Rust build step's parser. Previously they were being stored in the `RcDom` instance's `errors` vector, and ignored. Now they are threaded through to the final `io::Result`, and then output by `main()`.

The hardest part of this was adding line numbers to the errors. Doing this necessitated creating a wrapper for `RcDom`, which I inventively called `RcDomWithLineNumbers`, which implements `TreeSink` with two methods `parse_error` and `set_current_line` given custom behavior, while the other many methods just delegate to `RcDom`'s implementation.

(There doesn't appear to be any better way to do this in Rust, currently. If you search for "rust delegation" you'll find lots of discussion of the problem, and various solutions which work if you can modify the delegated-to class, i.e. `RcDom` in our case. But nothing seems to work if the delegated-to class is in third-party code.)

Additionally, this enables `exact_errors` as a parser option, which provides slightly more information in a couple of cases related to character references.

<details>
<summary>Original PR description</summary>

I spent some time trying to address https://github.com/whatwg/html-build/issues/290

This sort of works. (Although the code needs a lot of cleanup; probably we want to bubble the errors to the top level instead of printing them immediately.)

However, the biggest problem is that there is no line number information. So the output is terrible:

```
   Compiling html-build v0.0.0 (/home/domenic/src/html-build)
    Finished release [optimized] target(s) in 3.14s
     Running `target/release/html-build`
Attributes on an end tag
No matching tag to close
Error: Custom { kind: InvalidData, error: "Parse errors encountered" }
```

The upstream issue is https://github.com/servo/html5ever/issues/48 .

I think this is possible to fix if we do something where we override the `RcDom` sink so that instead of [doing nothing when `set_current_line` is called](https://docs.rs/markup5ever/0.11.0/src/markup5ever/interface/tree_builder.rs.html#238), it stores that information somewhere. And then I guess we'd override [the `parse_error` implementation](https://docs.rs/markup5ever_rcdom/latest/src/markup5ever_rcdom/lib.rs.html#224-226) to use that stored information.

Figuring out how to create some version of `RcDom` with these overrides seems likely to be something Rust supports, but I'm running out time for playing with Rust today. If anyone else wants to pitch in, patches are appreciated.
</summary>

/cc @noamr @jeremyroman 
