### PR TITLE
Move the --no-pager argument to avoid error

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -229,7 +229,7 @@ function checkHTMLBuildIsUpToDate {
     echo -n "Your local branch is $new_commits "
     [[ $new_commits == "1" ]] && echo -n "commit" || echo -n "commits"
     echo " behind $origin_url:"
-    git log --no-pager --oneline HEAD..FETCH_HEAD
+    git --no-pager log --oneline HEAD..FETCH_HEAD
     echo
     echo "To update, run this command:"
     echo


### PR DESCRIPTION
The error with git version 2.45.0.rc0.197.gbae5840b3b-goog on macOS:

> fatal: unrecognized argument: --no-pager
