### PR TITLE
Fix CI Docker publication

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,14 +16,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout whatwg/html-build
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           components: rustfmt, clippy
       - name: Cache Cargo dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -43,18 +43,22 @@ jobs:
           shellcheck *.sh
           shellcheck ci-build/*.sh
 
-  build-and-test-image:
-    name: Build and Test Image
+  build-and-publish:
+    name: Build and Publish
     runs-on: ubuntu-latest
+    needs: [static-checks]
+    permissions:
+      contents: read
+      packages: write
     steps:
     - name: Checkout whatwg/html-build
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Docker build
       run: ci-build/docker-build.sh
     - name: Checkout whatwg/html
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: whatwg/html
         path: html
@@ -63,23 +67,15 @@ jobs:
       run: |
         mkdir output
         bash ci-build/docker-run.sh "$GITHUB_WORKSPACE/html" output
-
-  publish:
-    name: Publish
-    runs-on: ubuntu-latest
-    needs: [static-checks, build-and-test-image]
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-    permissions:
-      contents: read
-      packages: write
-    steps:
     - name: Docker login
-      uses: docker/login-action@v2
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      uses: docker/login-action@v3
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Docker push
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       run: |
         docker tag "$REGISTRY/$IMAGE_NAME" "$REGISTRY/$IMAGE_NAME:$GITHUB_SHA"
         docker tag "$REGISTRY/$IMAGE_NAME" "$REGISTRY/$IMAGE_NAME:latest"


### PR DESCRIPTION
accb46d67a190281bc2acd7025092787e83363cb introduced a bug into the CI process where it tried to publish a Docker image in a separate job from building and testing that image. That doesn't really work. Merge those two jobs back together.

Also, bump all the GitHub Actions versions.