### PR TITLE
Fix incorrect variable name in "confirmRepo"

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -392,7 +392,7 @@ function confirmRepo {
       echo
 
       local build_yn
-      read -r -e -p "Y or N? " yn
+      read -r -e -p "Y or N? " build_yn
       if [[ $build_yn == "y" || $build_yn == "Y" ]]; then
         return
       else


### PR DESCRIPTION
On local builds, the "build.sh" scripts was giving me the following error:

```bash
Y or N? y
./build.sh: line 396: build_yn: unbound variable
```

I changed the `yn` variable to `build_yn` and problems is fixed.