### PR TITLE
Refactor parser utils to return the RcDomWithLineNumbers

### DIFF
--- a/src/annotate_attributes.rs
+++ b/src/annotate_attributes.rs
@@ -311,7 +311,7 @@ mod tests {
         // before and after the attributes table, to demonstrate that this is
         // not sensitive to which order they occur in (i.e., these could be
         // reordered in the HTML spec).
-        let document = parse_document_async(
+        let parsed = parse_document_async(
             r#"
 <!DOCTYPE html>
 <h3>The a element</h3>
@@ -333,6 +333,7 @@ mod tests {
     <dd><code data-x="attr-area-href">href</code>
 </dl>
             "#.trim().as_bytes()).await?;
+        let document = parsed.document().clone();
         let mut proc = Processor::new();
         dom_utils::scan_dom(&document, &mut |h| proc.visit(h));
         proc.apply().await?;
@@ -368,7 +369,7 @@ mod tests {
     async fn test_variant() -> io::Result<()> {
         // This checks that <!-- variant --> and <!-- or: --> work correctly.
         // i.e., the variant description is used where requested
-        let document = parse_document_async(
+        let parsed = parse_document_async(
             r#"
 <!DOCTYPE html>
 <h3>The a element</h3>
@@ -386,6 +387,7 @@ mod tests {
     <dd><code data-x="attr-area-href">href</code><!-- variant -->
 </dl>
             "#.trim().as_bytes()).await?;
+        let document = parsed.document().clone();
         let mut proc = Processor::new();
         dom_utils::scan_dom(&document, &mut |h| proc.visit(h));
         proc.apply().await?;
@@ -415,7 +417,7 @@ mod tests {
     #[tokio::test]
     async fn test_special_semantics() -> io::Result<()> {
         // Checks that the special rules for using : instead of an em dash work.
-        let document = parse_document_async(
+        let parsed = parse_document_async(
             r#"
 <!DOCTYPE html>
 <h3>The a element</h3>
@@ -428,6 +430,7 @@ mod tests {
     <tr><th><code data-x>name</code><td><code data-x="attr-a-name">a</code><td>Anchor name
 </tbody></table>
             "#.trim().as_bytes()).await?;
+        let document = parsed.document().clone();
         let mut proc = Processor::new();
         dom_utils::scan_dom(&document, &mut |h| proc.visit(h));
         proc.apply().await?;
@@ -451,7 +454,7 @@ mod tests {
     #[tokio::test]
     async fn test_special_semantics_multiple() -> io::Result<()> {
         // Checks that the special rules for joining any special semantics with a ; work.
-        let document = parse_document_async(
+        let parsed = parse_document_async(
             r#"
 <!DOCTYPE html>
 <h3>The a element</h3>
@@ -465,6 +468,7 @@ mod tests {
     <tr><th><code data-x>name</code><td><code data-x="attr-a-name">a</code><td>Name of the anchor
 </tbody></table>
             "#.trim().as_bytes()).await?;
+        let document = parsed.document().clone();
         let mut proc = Processor::new();
         dom_utils::scan_dom(&document, &mut |h| proc.visit(h));
         proc.apply().await?;
@@ -490,7 +494,7 @@ mod tests {
     async fn test_identical_links() -> io::Result<()> {
         // This checks the same identifier can be linked multiple times without
         // repeating the description.
-        let document = parse_document_async(
+        let parsed = parse_document_async(
             r#"
 <!DOCTYPE html>
 <h3>The img element</h3>
@@ -508,6 +512,7 @@ mod tests {
     <tr><th><code data-x>width</code><td><code data-x="attr-dim-width">img</code>; <code data-x="attr-dim-width">video</code><td>Horizontal dimension
 </tbody></table>
             "#.trim().as_bytes()).await?;
+        let document = parsed.document().clone();
         let mut proc = Processor::new();
         dom_utils::scan_dom(&document, &mut |h| proc.visit(h));
         proc.apply().await?;

--- a/src/boilerplate.rs
+++ b/src/boilerplate.rs
@@ -166,10 +166,11 @@ mod tests {
             "<tr><td>en<td>English",
         )
         .await?;
-        let document = parse_document_async(
+        let parsed = parse_document_async(
             "<!DOCTYPE html><table><!--BOILERPLATE languages--></table>".as_bytes(),
         )
         .await?;
+        let document = parsed.document().clone();
         let mut proc = Processor::new(boilerplate_dir.path(), Path::new("."));
         dom_utils::scan_dom(&document, &mut |h| proc.visit(h));
         proc.apply().await?;
@@ -188,10 +189,11 @@ mod tests {
             "data:text/html,Hello, world!",
         )
         .await?;
-        let document = parse_document_async(
+        let parsed = parse_document_async(
             "<!DOCTYPE html><a href=\"<!--BOILERPLATE data.url-->\">hello</a>".as_bytes(),
         )
         .await?;
+        let document = parsed.document().clone();
         let mut proc = Processor::new(boilerplate_dir.path(), Path::new("."));
         dom_utils::scan_dom(&document, &mut |h| proc.visit(h));
         proc.apply().await?;
@@ -208,9 +210,10 @@ mod tests {
         tokio::fs::write(example_dir.path().join("ex1"), "first").await?;
         tokio::fs::write(example_dir.path().join("ex2"), "second").await?;
         tokio::fs::write(example_dir.path().join("ignored"), "bad").await?;
-        let document =
+        let parsed =
             parse_document_async("<!DOCTYPE html><pre>EXAMPLE ex1</pre><pre><code class=html>\nEXAMPLE ex2  </code></pre><p>EXAMPLE ignored</p>".as_bytes())
                 .await?;
+        let document = parsed.document().clone();
         let mut proc = Processor::new(Path::new("."), example_dir.path());
         dom_utils::scan_dom(&document, &mut |h| proc.visit(h));
         proc.apply().await?;
@@ -229,7 +232,8 @@ mod tests {
             "<!DOCTYPE html><body><pre>EXAMPLE ../foo</pre>",
         ];
         for example in bad_path_examples {
-            let document = parse_document_async(example.as_bytes()).await?;
+            let parsed = parse_document_async(example.as_bytes()).await?;
+            let document = parsed.document().clone();
             let mut proc = Processor::new(Path::new("."), Path::new("."));
             dom_utils::scan_dom(&document, &mut |h| proc.visit(h));
             let result = proc.apply().await;

--- a/src/interface_index.rs
+++ b/src/interface_index.rs
@@ -186,7 +186,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_two_interfaces_in_one_block() -> io::Result<()> {
-        let document = parse_document_async(
+        let parsed = parse_document_async(
             r#"
 <!DOCTYPE html>
 <pre><code class=idl>
@@ -199,6 +199,7 @@ INSERT INTERFACES HERE
             .as_bytes(),
         )
         .await?;
+        let document = parsed.document().clone();
         let mut proc = Processor::new();
         dom_utils::scan_dom(&document, &mut |h| proc.visit(h));
         proc.apply()?;
@@ -216,7 +217,7 @@ interface <dfn interface="">HTMLBlinkElement</dfn> { ... }
 
     #[tokio::test]
     async fn test_two_interfaces_in_separate_blocks() -> io::Result<()> {
-        let document = parse_document_async(
+        let parsed = parse_document_async(
             r#"
 <!DOCTYPE html>
 <pre><code class=idl>
@@ -231,6 +232,7 @@ INSERT INTERFACES HERE
             .as_bytes(),
         )
         .await?;
+        let document = parsed.document().clone();
         let mut proc = Processor::new();
         dom_utils::scan_dom(&document, &mut |h| proc.visit(h));
         proc.apply()?;
@@ -250,7 +252,7 @@ interface <dfn interface="">HTMLBlinkElement</dfn> { ... }
 
     #[tokio::test]
     async fn interface_with_partial() -> io::Result<()> {
-        let document = parse_document_async(
+        let parsed = parse_document_async(
             r#"
 <!DOCTYPE html>
 <pre><code class=idl>
@@ -265,6 +267,7 @@ INSERT INTERFACES HERE
             .as_bytes(),
         )
         .await?;
+        let document = parsed.document().clone();
         let mut proc = Processor::new();
         dom_utils::scan_dom(&document, &mut |h| proc.visit(h));
         proc.apply()?;
@@ -284,7 +287,7 @@ partial interface <span id="HTMLMarqueeElement-partial">HTMLMarqueeElement</span
 
     #[tokio::test]
     async fn interface_with_two_partials() -> io::Result<()> {
-        let document = parse_document_async(
+        let parsed = parse_document_async(
             r#"
 <!DOCTYPE html>
 <pre><code class=idl>
@@ -298,6 +301,7 @@ INSERT INTERFACES HERE
             .as_bytes(),
         )
         .await?;
+        let document = parsed.document().clone();
         let mut proc = Processor::new();
         dom_utils::scan_dom(&document, &mut |h| proc.visit(h));
         proc.apply()?;
@@ -316,7 +320,7 @@ partial interface <span id="HTMLMarqueeElement-partial-2">HTMLMarqueeElement</sp
 
     #[tokio::test]
     async fn only_partials() -> io::Result<()> {
-        let document = parse_document_async(
+        let parsed = parse_document_async(
             r#"
 <!DOCTYPE html>
 <pre><code class=idl>
@@ -329,6 +333,7 @@ INSERT INTERFACES HERE
             .as_bytes(),
         )
         .await?;
+        let document = parsed.document().clone();
         let mut proc = Processor::new();
         dom_utils::scan_dom(&document, &mut |h| proc.visit(h));
         proc.apply()?;
@@ -346,7 +351,7 @@ partial interface <span id="HTMLMarqueeElement-partial-2">HTMLMarqueeElement</sp
 
     #[tokio::test]
     async fn marker_before() -> io::Result<()> {
-        let document = parse_document_async(
+        let parsed = parse_document_async(
             r#"
 <!DOCTYPE html>
 INSERT INTERFACES HERE
@@ -358,6 +363,7 @@ interface <dfn interface>HTMLMarqueeElement</dfn> { ... }
             .as_bytes(),
         )
         .await?;
+        let document = parsed.document().clone();
         let mut proc = Processor::new();
         dom_utils::scan_dom(&document, &mut |h| proc.visit(h));
         proc.apply()?;
@@ -376,7 +382,8 @@ interface <dfn interface="">HTMLMarqueeElement</dfn> { ... }
 
     #[tokio::test]
     async fn no_marker() -> io::Result<()> {
-        let document = parse_document_async("<!DOCTYPE html>".as_bytes()).await?;
+        let parsed = parse_document_async("<!DOCTYPE html>".as_bytes()).await?;
+        let document = parsed.document().clone();
         let mut proc = Processor::new();
         dom_utils::scan_dom(&document, &mut |h| proc.visit(h));
         let result = proc.apply();
@@ -386,11 +393,12 @@ interface <dfn interface="">HTMLMarqueeElement</dfn> { ... }
 
     #[tokio::test]
     async fn duplicate_marker() -> io::Result<()> {
-        let document = parse_document_async(
+        let parsed = parse_document_async(
             "<!DOCTYPE html><div>INSERT INTERFACES HERE</div><div>INSERT INTERFACES HERE</div>"
                 .as_bytes(),
         )
         .await?;
+        let document = parsed.document().clone();
         let mut proc = Processor::new();
         dom_utils::scan_dom(&document, &mut |h| proc.visit(h));
         let result = proc.apply();
@@ -400,7 +408,7 @@ interface <dfn interface="">HTMLMarqueeElement</dfn> { ... }
 
     #[tokio::test]
     async fn duplicate_dfn() -> io::Result<()> {
-        let document = parse_document_async(
+        let parsed = parse_document_async(
             r#"
 <!DOCTYPE html>
 <pre><code class=idl>
@@ -411,6 +419,7 @@ interface <dfn interface>HTMLMarqueeElement</dfn> { ... }
             .as_bytes(),
         )
         .await?;
+        let document = parsed.document().clone();
         let mut proc = Processor::new();
         dom_utils::scan_dom(&document, &mut |h| proc.visit(h));
         let result = proc.apply();

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,8 @@ async fn run_preprocess() -> io::Result<()> {
     // Because parsing can jump around the tree a little, it's most reasonable
     // to just parse the whole document before doing any processing. Even for
     // the HTML standard, this doesn't take too long.
-    let document = parser::parse_document_async(tokio::io::stdin()).await?;
+    let parsed = parser::parse_document_async(tokio::io::stdin()).await?;
+    let document = parsed.document().clone();
 
     let mut boilerplate = boilerplate::Processor::new(cache_dir.clone(), source_dir.join("demos"));
     let mut represents = represents::Processor::new();
@@ -92,7 +93,8 @@ async fn run_preprocess() -> io::Result<()> {
 
 // The steps and considerations here are similar to run_preprocess.
 async fn run_postprocess() -> io::Result<()> {
-    let document = parser::parse_document_async(tokio::io::stdin()).await?;
+    let parsed = parser::parse_document_async(tokio::io::stdin()).await?;
+    let document = parsed.document().clone();
 
     let mut anchor_permanence = anchor_permanence::Processor::new();
 

--- a/src/rcdom_with_line_numbers.rs
+++ b/src/rcdom_with_line_numbers.rs
@@ -17,6 +17,13 @@ pub struct RcDomWithLineNumbers {
     current_line: Cell<u64>,
 }
 
+#[cfg(test)]
+impl std::fmt::Debug for RcDomWithLineNumbers {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("RcDomWithLineNumbers")
+    }
+}
+
 impl RcDomWithLineNumbers {
     // Expose out the document and errors from the inner RcDom
     pub fn document(&self) -> &Handle {

--- a/src/represents.rs
+++ b/src/represents.rs
@@ -128,7 +128,8 @@ mod tests {
     #[tokio::test]
     async fn test_represents() -> io::Result<()> {
         // Uses can occur either before or after.
-        let document = parse_document_async("<!DOCTYPE html><p><!--REPRESENTS chair--><p>The <code>chair</code> element <span>represents</span> a seat\nat a <code>table</code>.<p><!--REPRESENTS chair-->".as_bytes()).await?;
+        let parsed = parse_document_async("<!DOCTYPE html><p><!--REPRESENTS chair--><p>The <code>chair</code> element <span>represents</span> a seat\nat a <code>table</code>.<p><!--REPRESENTS chair-->".as_bytes()).await?;
+        let document = parsed.document().clone();
         let mut proc = Processor::new();
         dom_utils::scan_dom(&document, &mut |h| proc.visit(h));
         proc.apply()?;
@@ -142,7 +143,8 @@ mod tests {
     #[tokio::test]
     async fn test_represents_undefined() -> io::Result<()> {
         // Uses can occur either before or after.
-        let document = parse_document_async("<!DOCTYPE html><p><!--REPRESENTS chain--><p>The <code>chair</code> element <span>represents</span> a seat\nat a <code>table</code>.<p><!--REPRESENTS chair-->".as_bytes()).await?;
+        let parsed = parse_document_async("<!DOCTYPE html><p><!--REPRESENTS chain--><p>The <code>chair</code> element <span>represents</span> a seat\nat a <code>table</code>.<p><!--REPRESENTS chair-->".as_bytes()).await?;
+        let document = parsed.document().clone();
         let mut proc = Processor::new();
         dom_utils::scan_dom(&document, &mut |h| proc.visit(h));
         let result = proc.apply();

--- a/src/tag_omission.rs
+++ b/src/tag_omission.rs
@@ -203,7 +203,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_simple() -> io::Result<()> {
-        let document = parse_document_async(
+        let parsed = parse_document_async(
             r#"
 <!DOCTYPE html>
 <h3>Optional tags</h3>
@@ -252,6 +252,7 @@ mod tests {
             .as_bytes(),
         )
         .await?;
+        let document = parsed.document().clone();
         let mut proc = Processor::new();
         dom_utils::scan_dom(&document, &mut |h| proc.visit(h));
         proc.apply()?;


### PR DESCRIPTION
This allows the various processors access to not just the Document, but the RcDomWithLineNumbers instance. This is useful for various operations; subsequent commits, for example, will store the line numbers and use them in error message displays.