### PR TITLE
Disable block-level Markdown in Bikeshed

### DIFF
--- a/wattsi2bikeshed.js
+++ b/wattsi2bikeshed.js
@@ -10,7 +10,7 @@ Text Macro: TWITTER htmlstandard
 Text Macro: LATESTRD 2025-01
 Abstract: HTML is Bikeshed.
 Indent: 1
-Markup Shorthands: css off
+Markup Shorthands: css off, markdown-block off
 Complain About: accidental-2119 off, missing-example-ids off
 Include MDN Panels: false
 </pre>`;


### PR DESCRIPTION
Skipping this gives a small performance improvement, and avoids having to
escape what looks like numbered lists.

Depends on https://github.com/speced/bikeshed/pull/3186.
