### PR TITLE
Fix Wattsi "topic" emulation for [[StringsLikeThis]]

### DIFF
--- a/wattsi2bikeshed.js
+++ b/wattsi2bikeshed.js
@@ -68,7 +68,8 @@ function getId(topic) {
     // Note: no toLowerCase() because this is already done in getTopic().
     return topic
         .replaceAll(/["?`]/g, '')
-        .replaceAll(/[\s<>\[\\\]^{|}%]+/g, '-');
+        .replaceAll(/[\s<>\[\\\]^{|}%]+/g, ' ').trim()
+        .replaceAll(' ', '-');
 }
 
 // Get the linking text like Bikeshed:


### PR DESCRIPTION
The space-like characters weren't being suppressed from the beginning
and end of the string, like they are with the HadSpace logic in Wattsi.
